### PR TITLE
Better qualification on names

### DIFF
--- a/ghc/GhciFind.hs
+++ b/ghc/GhciFind.hs
@@ -203,7 +203,7 @@ findType :: GhcMonad m
          -> Int
          -> Int
          -> Int
-         -> m (Either String Type)
+         -> m (Either String (ModInfo, Type))
 findType infos fp string sl sc el ec =
   do mname <- guessModule infos fp
      case mname of
@@ -221,9 +221,9 @@ findType infos fp string sl sc el ec =
                                   el
                                   ec
                 case mty of
-                  Just ty -> return (Right ty)
+                  Just ty -> return (Right (info, ty))
                   Nothing ->
-                    fmap Right (exprType string)
+                    fmap (Right . (,) info) (exprType string)
 
 -- | Try to resolve the type display from the given span.
 resolveType :: [SpanInfo] -> Int -> Int -> Int -> Int -> Maybe Type

--- a/ghc/GhciMonad.hs
+++ b/ghc/GhciMonad.hs
@@ -19,7 +19,7 @@ module GhciMonad (
         getDynFlags,
 
         runStmt, runDecls, resume, timeIt, recordBreak, revertCAFs,
-        printForUserNeverQualify,
+        printForUserNeverQualify, printForUserModInfo,
 
         printForUser, printForUserPartWay, prettyLocations,
         initInterpBuffering, turnOffBuffering, flushInterpBuffers,
@@ -255,7 +255,14 @@ unsetOption opt
 printForUserNeverQualify :: GhcMonad m => SDoc -> m ()
 printForUserNeverQualify doc = do
   dflags <- getDynFlags
-  liftIO $ Outputable.printForUser dflags stdout (neverQualifyNames,neverQualifyModules) doc
+  liftIO $ Outputable.printForUser dflags stdout neverQualify doc
+
+printForUserModInfo :: GhcMonad m => GHC.ModuleInfo -> SDoc -> m ()
+printForUserModInfo info doc = do
+  dflags <- getDynFlags
+  mUnqual <- GHC.mkPrintUnqualifiedForModule info
+  unqual <- maybe GHC.getPrintUnqual return mUnqual
+  liftIO $ Outputable.printForUser dflags stdout unqual doc
 
 printForUser :: GhcMonad m => SDoc -> m ()
 printForUser doc = do

--- a/ghc/InteractiveUI.hs
+++ b/ghc/InteractiveUI.hs
@@ -1524,9 +1524,9 @@ typeAt str =
             result <- findType infos fp sample sl sc el ec
             case result of
               Left err -> liftIO (putStrLn err)
-              Right ty ->
-                printForUserNeverQualify
-                  (sep [text sample,nest 2 (dcolon <+> pprTypeForUser ty)]))
+              Right (info, ty) ->
+                printForUserModInfo (modinfoInfo info)
+                  (sep [text sample,nest 2 (dcolon <+> ppr ty)]))
 
 -----------------------------------------------------------------------------
 -- :uses


### PR DESCRIPTION
Qualify names just like GHC does in its warnings/error messages, which is a much better fit for [C-u] C-c C-t.
