### PR TITLE
Don't print "Wrote <file>" message on flycheck

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -256,7 +256,7 @@ running context across :load/:reloads in Intero."
 (defun intero-check (checker cont)
   "Run a check and pass the status onto CONT."
   (let ((file-buffer (current-buffer)))
-    (write-region (point-min) (point-max) (intero-buffer-file-name))
+    (write-region (point-min) (point-max) (intero-buffer-file-name) nil 'no-message)
     (clear-visited-file-modtime)
     (intero-async-call
      'backend


### PR DESCRIPTION
In defun intero-check, calling write-region will print a message "Wrote
<file>". In my environment, flycheck always happens after doing "C-c
C-t". And the "Wrote <file>" makes the type information in my minibuffer
gone in one second or so. This is really annoying.