### PR TITLE
Added default key bindings in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Please see
 
 ### Default key bindings
 
-. intero-goto-definition `M-.`
-. intero-info `C-c TAB`
-. intero-repl-load `C-c C-l`
-. intero-type-at `C-c C-t`
+- intero-goto-definition `M-.`
+- intero-info `C-c TAB`
+- intero-repl-load `C-c C-l`
+- intero-type-at `C-c C-t`
 
 ## Intero for IDE writers
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ Complete interactive development program for Haskell
 Please see
 [the homepage for Intero for Emacs](http://commercialhaskell.github.io/intero).
 
+### Default key bindings
+
+. intero-goto-definition `M-.`
+. intero-info `C-c TAB`
+. intero-repl-load `C-c C-l`
+. intero-type-at `C-c C-t`
+
 ## Intero for IDE writers
 
 Please see


### PR DESCRIPTION
I thought it should be great to display the default provided key bindings for Emacs (especially intero-repl-load which is missing in http://commercialhaskell.github.io/intero/).

Thanks for your awesome work!