### PR TITLE
Save current buffer before loading REPL

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -469,6 +469,7 @@ warnings, adding CHECKER and BUFFER to each one."
 (defun intero-repl-load ()
   "Load the current file in the REPL."
   (interactive)
+  (save-buffer)
   (let ((file (intero-buffer-file-name))
         (repl-buffer (intero-repl-buffer)))
     (with-current-buffer repl-buffer


### PR DESCRIPTION
People used to the `interactive-haskell-mode`  REPL loading behaviour (`C-c C-l`) expect the current buffer to be saved before loading.

To demonstrate the current behaviour, define:

```haskell
foo = putStrLn "hey"
```
Save, `C-c C-l` and test the value of foo. The repl will print `hey`.

Now change `foo` to:

```haskell
foo = putStrLn "hi"
```
and without saving, load the repl again with `C-c C-l`. `foo` will still print `hey`.