### PR TITLE
Added mandatory enable option for NixOS.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -5,4 +5,5 @@ extra-deps: []
 flags: {}
 extra-package-dbs: []
 nix:
+  enable: true
   packages: [ ncurses ]


### PR DESCRIPTION
In order to fix the intero integration for NixOS, one solution is to modify the `~/.stack/config.yaml` as described in #52, but we need both the *ncurses* package and [nix to be enabled](http://docs.haskellstack.org/en/stable/nix_integration/#additions-to-your-stackyaml):

```yaml
nix:
  enable: true
  packages: [ ncurses ]
```

Best solution is to add these default options in the `stack/config.yaml` of the project!

