### PR TITLE
Bump auto-installed intero version

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -63,7 +63,7 @@
   :group 'haskell)
 
 (defcustom intero-package-version
-  "0.1.15"
+  "0.1.16"
   "Package version to auto-install."
   :group 'intero
   :type 'string)


### PR DESCRIPTION
Bump the auto-installed intero version in the elisp file to be the latest version, 0.1.16.