### PR TITLE
Partially working jump-to-error

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -764,7 +764,7 @@ If PROMPT-OPTIONS is non-nil, prompt with an options list."
   "Opens the file from 'file text property and moves to line:char from 'line text property."
   (let ((file (get-text-property (point) 'file))
         (line:char (get-text-property (point) 'line)))
-    (with-no-warnings (find-file-other-frame file))
+    (with-no-warnings (find-file-other-window file))
     (if (string-match "^\\([0-9]+\\):?\\([0-9]*\\)$" line:char 0)
         (let ((line (string-to-number (match-string 1 line:char)))
               (char (string-to-number (match-string 2 line:char))))

--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -1258,8 +1258,8 @@ Automatically performs initial actions in SOURCE-BUFFER, if specified."
                       (when intero-debug
                         (message "Intero arguments: %s" (combine-and-quote-strings arguments)))
                       (message "Booting up intero ...")
-                      (get-buffer-process (apply #'start-process "stack" buffer "stack" "ghci"
-                             arguments)))))
+                      (apply #'start-process "stack" buffer "stack" "ghci"
+                             arguments))))
       (set-process-query-on-exit-flag process nil)
       (process-send-string process ":set -fobject-code\n")
       (process-send-string process ":set prompt \"\\4\"\n")

--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -722,9 +722,9 @@ If PROMPT-OPTIONS is non-nil, prompt with an options list."
   (let ((file (intero-buffer-file-name))
         (repl-buffer (intero-repl-buffer prompt-options)))
     (with-current-buffer repl-buffer
-      (comint-send-string
+      (comint-simple-send
        (get-buffer-process (current-buffer))
-       (concat ":l " file "\n")))
+       (concat ":l " file)))
     (pop-to-buffer repl-buffer)))
 
 (defun intero-repl (&optional prompt-options)
@@ -781,7 +781,8 @@ If PROMPT-OPTIONS is non-nil, prompt with an options list."
   "Linkify all occurances of <file>:<line>:<char>: betwen begin and end"
   (let ((end-marker (copy-marker end))
         (file:line:char-regexp (concat "[\r\n]\\([A-Z]?:?[^ \r\n:][^:\n\r]+\\):\\([0-9()-:]+\\):"
-                                       "[ \n\r]+\\([[:unibyte:][:nonascii:]]+?\\)\n[^ ]")))
+                                       ;; "[ \n\r]+\\([[:unibyte:][:nonascii:]]+?\\)\n[^ ]"
+                                       )))
     (save-excursion
       (goto-char begin)
       ;; Delete unrecognized escape sequences.
@@ -844,11 +845,11 @@ If PROMPT-OPTIONS is non-nil, prompt with an options list."
 ")
                     (basic-save-buffer)
                     (intero-buffer-file-name))))
-      (let ((process (apply #'start-process "intero" (current-buffer) "stack" "ghci"
-                            (append arguments
-                                    (list "--verbosity" "silent")
-                                    (list "--ghci-options"
-                                          (concat "-ghci-script=" script))))))
+      (let ((process (get-buffer-process (apply #'make-comint-in-buffer "intero" (current-buffer) "stack" nil "ghci"
+                                               (append arguments
+                                                       (list "--verbosity" "silent")
+                                                       (list "--ghci-options"
+                                                             (concat "-ghci-script=" script)))))))
         (when (process-live-p process)
           (set-process-query-on-exit-flag process nil)
           (message "Started Intero process for REPL."))))))

--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -1258,11 +1258,11 @@ Automatically performs initial actions in SOURCE-BUFFER, if specified."
                       (when intero-debug
                         (message "Intero arguments: %s" (combine-and-quote-strings arguments)))
                       (message "Booting up intero ...")
-                      (get-buffer-process (apply #'make-comint-in-buffer "stack" buffer "stack" nil "ghci"
+                      (get-buffer-process (apply #'start-process "stack" buffer "stack" "ghci"
                              arguments)))))
       (set-process-query-on-exit-flag process nil)
-      (comint-simple-send process ":set -fobject-code")
-      (comint-simple-send process ":set prompt \"\\4\"")
+      (process-send-string process ":set -fobject-code\n")
+      (process-send-string process ":set prompt \"\\4\"\n")
       (with-current-buffer buffer
         (erase-buffer)
         (setq intero-targets targets)


### PR DESCRIPTION
This is basically as far as I came. Any input would be much appreciated.
- style
- naming
- ...

The `comint-output-filter-functions` hook is *not* called when a buffer is loaded through `C-c C-l`, which I could not figure out why. It also keep reprocessing the whole buffer, which is why it actually works when hitting `ret` on the prompt after a broken file was loaded...

We might also want to consider setting (and making it configurable)
- `comint-buffer-maximum-size`
- `comint-input-ring-size`

To limit the buffer's size to a sensible amount of history?