### PR TITLE
Sort on column as well.

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -1985,10 +1985,13 @@ suggestions are available."
         (message "No changes selected to apply.")
       (let ((sorted (sort to-apply
                           (lambda (lt gt)
-                            (> (or (plist-get lt :line)
-                                   0)
-                               (or (plist-get gt :line)
-                                   0))))))
+                            (let ((lt-line   (or (plist-get lt :line)   0))
+                                  (lt-column (or (plist-get lt :column) 0))
+                                  (gt-line   (or (plist-get gt :line)   0))
+                                  (gt-column (or (plist-get gt :column) 0)))
+                              (or (> lt-line gt-line)
+                                  (and (= lt-line gt-line)
+                                       (> lt-column gt-column))))))))
         ;; # Changes that do not increase/decrease line numbers
         ;;
         ;; Update in-place suggestions


### PR DESCRIPTION
Quickfix already sorts the lines backwards to apply fixes, as they may
change the source location.  This however bearks down if two changes
happen in the same line.  Hence we add the column to the sort criteria
as well, such that corrections in the same line are applied in reverse
as well.

Fixes #202