### PR TITLE
Add program identifier to version command flag.

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -96,7 +96,7 @@ main = do
     -- 1. extract the -B flag from the args
     argv00 <- getArgs
     if elem "--version" argv00
-       then do putStrLn (Data.Version.showVersion Paths_intero.version)
+       then do putStrLn ("Intero " ++ Data.Version.showVersion Paths_intero.version)
                exitSuccess
        else return ()
     case lookup "STACK_EXE" env of


### PR DESCRIPTION
This will be used so that stack can interrogate what executable it is running against to know if it should use features available in intero, or just GHCi.