### PR TITLE
Message instead of error on lack of suggestions.

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -2005,7 +2005,7 @@ suggestions are available."
   "Prompt and apply the suggestions."
   (interactive)
   (when (null intero-suggestions)
-    (error "No suggestions to apply"))
+    (message "No suggestions to apply"))
   (let ((to-apply
          (intero-multiswitch
           (format "There are %d suggestions to apply:" (length intero-suggestions))


### PR DESCRIPTION
Very simple fix for https://github.com/commercialhaskell/intero/issues/227.
I noticed that the entire package uses this style, but in this case it does not seem like dropping into a debugger brings any advantage. It saves the user one `q` :)