### PR TITLE
Fixed unset of extensions.

### DIFF
--- a/src/InteractiveUI.hs
+++ b/src/InteractiveUI.hs
@@ -2580,6 +2580,7 @@ unsetOptions str
            ]
 
          no_flag ('-':'f':rest) = return ("-fno-" ++ rest)
+         no_flag ('-':'X':rest) = return ("-XNo" ++ rest)
          no_flag f = throwGhcException (ProgramError ("don't know how to reverse " ++ f))
 
      in if (not (null rest3))


### PR DESCRIPTION
:unset now has the same behavior that exists in GHCi.