### PR TITLE
Don't drop the first company completion

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -1171,7 +1171,7 @@ passed to CONT in SOURCE-BUFFER."
         (mapcar
          (lambda (x)
            (replace-regexp-in-string "\\\"" "" x))
-         (cdr (split-string reply "\n" t))))))))
+         (split-string reply "\n" t)))))))
 
 (defun intero-get-repl-completions (source-buffer prefix cont)
   "Get REPL completions and send to SOURCE-BUFFER.


### PR DESCRIPTION
This is related to a comment I just left on an older commit; hopefully this adds some clarity.

I don't know why this `cdr` is needed. When intero gives back a single completion, this `cdr` drops it, preventing `company` from showing any completions at all. I may be unaware of the scenario where the `cdr` is needed. If so, apologies for the disturbance!