### PR TITLE
Replace temp filename with real filename (#248)

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -434,7 +434,8 @@ CHECKER and BUFFER are added to each item parsed from STRING."
     (insert string)
     (goto-char (point-min))
     (let ((messages (list))
-          (temp-file (intero-temp-file-name buffer)))
+          (temp-file (intero-temp-file-name buffer))
+          (real-file-name (intero-buffer-file-name buffer)))
       (while (search-forward-regexp
               (concat "[\r\n]\\([A-Z]?:?[^ \r\n:][^:\n\r]+\\):\\([0-9()-:]+\\):"
                       "[ \n\r]+\\([[:unibyte:][:nonascii:]]+?\\)\n[^ ]")
@@ -456,11 +457,11 @@ CHECKER and BUFFER are added to each item parsed from STRING."
           (setq messages
                 (cons (flycheck-error-new-at
                        line column type
-                       msg
+                       (replace-in-string msg temp-file real-file-name)
                        :checker checker
                        :buffer (when (string= temp-file file)
                                  buffer)
-                       :filename (intero-buffer-file-name buffer))
+                       :filename real-file-name)
                       messages)))
         (forward-line -1))
       (delete-dups messages))))


### PR DESCRIPTION
@purcell See any problem with this?

``` haskell
 Par...   68  28 error           Couldn't match expected type ‘[t0] -> P (a SrcSpanInfo)’
                with actual type ‘P (a SrcSpanInfo)’
    Relevant bindings include
      p :: P (a SrcSpanInfo)
        (bound at /var/folders/2s/6j1qqrgd57bg9ctkltrkn3z80000gn/T/intero52962niH.hs:68:22)
      normalParserNoFixity :: P (a SrcSpanInfo)
                              -> Maybe [Fixity] -> P (a SrcSpanInfo)
        (bound at /var/folders/2s/6j1qqrgd57bg9ctkltrkn3z80000gn/T/intero52962niH.hs:68:1)
    The function ‘p’ is applied to one argument,
    but its type ‘P (a SrcSpanInfo)’ has none
    In the expression: p []
    In an equation for ‘normalParserNoFixity’:
        normalParserNoFixity p _ = p []... (intero)
```

=>

``` haskell
Par...   68  28 error           Couldn't match expected type ‘[t0] -> P (a SrcSpanInfo)’
                with actual type ‘P (a SrcSpanInfo)’
    Relevant bindings include
      p :: P (a SrcSpanInfo)
        (bound at /Users/chris/Work/haskell-src-exts/src/Language/Haskell/Exts/Parser.hs:68:22)
      normalParserNoFixity :: P (a SrcSpanInfo)
                              -> Maybe [Fixity] -> P (a SrcSpanInfo)
        (bound at /Users/chris/Work/haskell-src-exts/src/Language/Haskell/Exts/Parser.hs:68:1)
    The function ‘p’ is applied to one argument,
    but its type ‘P (a SrcSpanInfo)’ has none
    In the expression: p []
    In an equation for ‘normalParserNoFixity’:
        normalParserNoFixity p _ = p []... (intero)
```