### PR TITLE
Revert "Replace temp filename with real filename (#248)"

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -434,8 +434,7 @@ CHECKER and BUFFER are added to each item parsed from STRING."
     (insert string)
     (goto-char (point-min))
     (let ((messages (list))
-          (temp-file (intero-temp-file-name buffer))
-          (real-file-name (intero-buffer-file-name buffer)))
+          (temp-file (intero-temp-file-name buffer)))
       (while (search-forward-regexp
               (concat "[\r\n]\\([A-Z]?:?[^ \r\n:][^:\n\r]+\\):\\([0-9()-:]+\\):"
                       "[ \n\r]+\\([[:unibyte:][:nonascii:]]+?\\)\n[^ ]")
@@ -457,11 +456,11 @@ CHECKER and BUFFER are added to each item parsed from STRING."
           (setq messages
                 (cons (flycheck-error-new-at
                        line column type
-                       (replace-in-string msg temp-file real-file-name)
+                       msg
                        :checker checker
                        :buffer (when (string= temp-file file)
                                  buffer)
-                       :filename real-file-name)
+                       :filename (intero-buffer-file-name buffer))
                       messages)))
         (forward-line -1))
       (delete-dups messages))))


### PR DESCRIPTION
Reverts commercialhaskell/intero#249

Not at a keyboard to fix this so I'll revert.