### PR TITLE
Be clear that warnings come from intero

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -1497,7 +1497,7 @@ You can always run M-x intero-restart to make it try again.
                          (funcall func state string))
                        (setq repeat t))
               (when intero-debug
-                (warn "Received output but no callback in `intero-callbacks': %S"
+                (intero--warn "Received output but no callback in `intero-callbacks': %S"
                       string)))))
         (delete-region (point-min) (point))))))
 
@@ -1561,7 +1561,7 @@ config exists."
                                      "--project-root"
                                      "--verbosity" "silent"))
               (0 (buffer-substring (line-beginning-position) (line-end-position)))
-              (t (warn "Couldn't get the Stack project root.
+              (t (intero--warn "Couldn't get the Stack project root.
 
 This can be caused by a syntax error in your stack.yaml file. Check that out.
 
@@ -2130,6 +2130,11 @@ suggestions are available."
                    (insert "{-# OPTIONS_GHC "
                            (plist-get suggestion :option)
                            " #-}\n"))))))))))
+
+(defun intero--warn (message &rest args)
+  "Display a warning message made from (format-message MESSAGE ARGS...).
+Equivalent to 'warn', but label the warning as coming from intero."
+  (display-warning 'intero (apply 'format-message message args) :warning))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
I got quite confused by this warning this morning:

```
Warning (emacs): Couldn’t get the Stack project root.

This can be caused by a syntax error in your stack.yaml file. Check that out.

Otherwise, please report this as a bug!
```

Where should I report this bug? Googling the error message found me https://hackage.haskell.org/package/intero-0.1.17/src/elisp/intero.el, which lead me here.

It seems a little odd to suggest that people report a bug without giving them a hint as to where (at the time, I had thought I had disabled intero, because it clearly didn't like me trying to edit a Haskell file that wasn't in a project.)

In any case, this PR updates the warning to say it's from intero, not emacs.

