### PR TITLE
Replace format-message with format

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -2188,9 +2188,9 @@ suggestions are available."
                            " #-}\n"))))))))))
 
 (defun intero--warn (message &rest args)
-  "Display a warning message made from (format-message MESSAGE ARGS...).
+  "Display a warning message made from (format MESSAGE ARGS...).
 Equivalent to 'warn', but label the warning as coming from intero."
-  (display-warning 'intero (apply 'format-message message args) :warning))
+  (display-warning 'intero (apply 'format message args) :warning))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
As discussed in https://github.com/commercialhaskell/intero/commit/bb2012df5e42ce657b51cf66d88f069563c7e5d7 .
My level of confidence is low: I have never written lisp code, I simply stumbled upon [a similar issue][1] that says `format-message` should be replaced with `format`. Please double-check.

[1]: https://gitlab.com/python-mode-devs/python-mode/issues/21