### PR TITLE
Display λ in prompt

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -934,22 +934,13 @@ changes in the BACKEND-BUFFER."
       (setq intero-repl-no-load (not (member "load-all" new-options)))
       (setq intero-repl-no-build (not (member "build-first" new-options))))))
 
-;; For live migration, remove later
-(font-lock-remove-keywords
- 'intero-repl-mode
- '(("\\(\4\\)"
-    (0 (prog1 ()
-         (compose-region (match-beginning 1)
-                         (match-end 1)
-                         ?λ))))))
-
 (font-lock-add-keywords
  'intero-repl-mode
  '(("\\(\4\\)"
     (0 (prog1 ()
          (compose-region (match-beginning 1)
                          (match-end 1)
-                         ?‽))))))
+                         ?λ))))))
 
 (define-key intero-repl-mode-map [remap move-beginning-of-line] 'intero-repl-beginning-of-line)
 (define-key intero-repl-mode-map [remap delete-backward-char] 'intero-repl-delete-backward-char)


### PR DESCRIPTION
i can not find any reason why we don't display `λ` in prompt but `‽`. i mean in every prompt of a FP language, there will be a `λ`. 😅 

Btw, there is one thing confusing me a lot while walking through the code base, why we need to [a temp file](https://github.com/commercialhaskell/intero/blob/master/elisp/intero.el#L1048-L1057), and all the infos are coming from the temp file, e.g. [type-at](https://github.com/commercialhaskell/intero/blob/master/elisp/intero.el#L1111) ?