### PR TITLE
Store temporary working files under .stack-work, not /tmp

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -1075,7 +1075,12 @@ The path returned is canonicalized and stripped of any text properties."
     (prog1
         (or intero-temp-file-name
             (setq intero-temp-file-name
-                  (intero-canonicalize-path (make-temp-file "intero" nil ".hs"))))
+                  (intero-canonicalize-path
+                   (let ((temporary-file-directory
+                          (expand-file-name ".stack-work/intero/"
+                                            (intero-project-root))))
+                     (make-directory temporary-file-directory t)
+                     (make-temp-file "intero" nil ".hs")))))
       (let ((contents (buffer-string)))
         (with-temp-file intero-temp-file-name
           (insert contents))))))


### PR DESCRIPTION
See #279. When enabling docker for stack, the docker image cannot see /tmp paths on the host system. With this change, .stack-work/intero/ is used as the location for temporary copies of the current working source file.

This commit does not change the containing directory for *all* intero temp files, because it is not clearly necessary to do so, but that might 
be a logical subsequent step for the sake of consistency.

Moving temp files to .stack-work/intero/ potentially allows intero to proactively delete all its temp files upon exit, which would be a win, since the code was previously relying on the OS to tidy up the temp dir.