### PR TITLE
bumping package version to auto-install

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -66,7 +66,7 @@
   :group 'haskell)
 
 (defcustom intero-package-version
-  "0.1.18"
+  "0.1.19"
   "Package version to auto-install.
 
 This version does not necessarily have to be the latest version


### PR DESCRIPTION
Intero 0.1.18 misses very important feature which makes inital haskell
experience less then ideal - not really representing the current state of
Intero. Completion of qualified identifiers should be considered essential and
as such It should justify bumping package version to 0.1.19