### PR TITLE
Use .lhs for temp files when necessary to match the current buffer

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -1091,7 +1091,11 @@ path."
         (or intero-temp-file-name
             (setq intero-temp-file-name
                   (intero-canonicalize-path
-                   (intero-make-temp-file "intero" nil ".hs"))))
+                   (intero-make-temp-file
+                    "intero" nil
+                    (concat "." (if (buffer-file-name)
+                                    (file-name-extension (buffer-file-name))
+                                  "hs"))))))
       (let ((contents (buffer-string)))
         (with-temp-file intero-temp-file-name
           (insert contents))))))


### PR DESCRIPTION
This addresses #311, in which .hs was wrongly used unconditionally.