### PR TITLE
Fix type of constructors in pattern

### DIFF
--- a/src/GhciInfo.hs
+++ b/src/GhciInfo.hs
@@ -6,9 +6,11 @@
 
 module GhciInfo (collectInfo,getModInfo,showppr) where
 
+import           ConLike
 import           Control.Exception
 import           Control.Monad
 import qualified CoreUtils
+import           DataCon
 import           Data.Data
 import           Data.Generics (GenericQ, mkQ, extQ)
 import           Data.List
@@ -152,13 +154,8 @@ getTypeLPat :: (GhcMonad m)
 getTypeLPat _ (L spn pat) =
   return (Just (getMaybeId pat,spn,getPatType pat))
   where
-    getPatType pat'@(ConPatOut _ _ _ _ _ args _) =
-      let argPats = hsConPatArgs args
-          getArgTy ty [] = ty
-          getArgTy ty ((L _ _h):_t) =
-            TyCoRep.ForAllTy (TyCoRep.Anon (getPatType _h)) $ getArgTy ty _t
-      in
-        getArgTy (hsPatType pat') argPats
+    getPatType pat'@(ConPatOut (L _ (RealDataCon dc)) _ _ _ _ _ _) =
+      dataConRepType dc
     getPatType pat' = hsPatType pat'
 #if __GLASGOW_HASKELL__ >= 800
     getMaybeId (VarPat (L _ vid)) = Just vid


### PR DESCRIPTION
Just simple fix for printed type of constructors

Reported by : https://github.com/commercialhaskell/intero/issues/67

However, there is some problem with existential types. For example,

``` Haskell
data Sh = forall a . Show a => Sh a

test (Sh x) = show x
```

In this case, printed type of `Sh` in piecewise definition of `test` is `a -> Sh`, and is not the correct type, i.e, `forall a . Show a => a -> Sh`.

This problem also can be fixed by collecting more data from `ConPatOut`, but I ran out of time so I make this PR first.