### PR TITLE
Remove unused import

### DIFF
--- a/src/GhciInfo.hs
+++ b/src/GhciInfo.hs
@@ -27,7 +27,6 @@ import           Outputable
 import           Prelude hiding (mod)
 import           System.Directory
 import           TcHsSyn
-import qualified TyCoRep
 import           Var
 
 #if MIN_VERSION_ghc(7,8,3)


### PR DESCRIPTION
Remove unused import that cause build error under (ghc < 8.0.0).