### PR TITLE
Template haskell expansion

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -384,24 +384,25 @@ Returns nil when unable to find definition."
 (defun intero-expand-splice-at-point ()
   "Show the expansion of the template haskell splice at point."
   (interactive)
-  (let* ((line (line-number-at-pos (point)))
-	 (pos (intero-thing-at-point))
-	 (beg (car pos))
-	 (start-column (save-excursion (goto-char beg)
-				       (current-column))))
-    (intero-async-call
-     'backend
-     (concat ":l " (intero-localize-path (intero-temp-file-name)))
-     (list :file-buffer (current-buffer)
-	   :line line
-	   :start start-column)
-     (lambda (state string)
-       (let* ((buffer (plist-get state :file-buffer))
-	      (line (plist-get state :line))
-	      (start (plist-get state :start))
-	      (expansion (intero-get-expansion-at-pos string buffer line start)))
-	 (when expansion
-	   (message (intero-fontify-expression expansion))))))))
+  (unless (intero-gave-up 'backend)
+    (let* ((line (line-number-at-pos (point)))
+	   (pos (intero-thing-at-point))
+	   (beg (car pos))
+	   (start-column (save-excursion (goto-char beg)
+					 (current-column))))
+      (intero-async-call
+       'backend
+       (concat ":l " (intero-localize-path (intero-temp-file-name)))
+       (list :file-buffer (current-buffer)
+	     :line line
+	     :start start-column)
+       (lambda (state string)
+	 (let* ((buffer (plist-get state :file-buffer))
+		(line (plist-get state :line))
+		(start (plist-get state :start))
+		(expansion (intero-get-expansion-at-pos string buffer line start)))
+	   (when expansion
+	     (message (intero-fontify-expression expansion))))))))
 
 (defun intero-restart ()
   "Simply restart the process with the same configuration as before."

--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -176,6 +176,7 @@ To use this, use the following mode hook:
 (define-key intero-mode-map (kbd "C-c C-l") 'intero-repl-load)
 (define-key intero-mode-map (kbd "C-c C-z") 'intero-repl)
 (define-key intero-mode-map (kbd "C-c C-r") 'intero-apply-suggestions)
+(define-key intero-mode-map (kbd "C-c C-e") 'intero-expand-splice-at-point)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Global variables/state
@@ -365,6 +366,42 @@ Returns nil when unable to find definition."
         (forward-line (1- line))
         (forward-char (1- col))
         t))))
+
+(defun intero-get-expansion-at-pos (string buffer line start)
+  "Take output from the background intero process as STRING, the current BUFFER, LINE and the the column of the START of the thing to expand.  Return the expansion of the the thing at START.  If there is no expansion at START, then return nil."
+  (let* ((column-regex (format "\\(%s\\|%s\\)" start (1+ start)))
+	 ;; ghci varies the column number of an expanded template haskell
+	 ;; expression according to whether it is parenthesised or not;
+	 ;; column-regex matches on either possibility.
+	 (regex (concat (intero-localize-path (intero-temp-file-name buffer))
+			(format ":%s:" line)
+			(format "%s" column-regex)
+			"\\(-[0-9]+\\)?: Splicing expression[ \t\n]*"
+			"\\(\\( .*\n\\)+\\)")))
+    (when (string-match regex string)
+      (match-string 3 string))))
+
+(defun intero-expand-splice-at-point ()
+  "Show the expansion of the template haskell splice at point."
+  (interactive)
+  (let* ((line (line-number-at-pos (point)))
+	 (pos (intero-thing-at-point))
+	 (beg (car pos))
+	 (start-column (save-excursion (goto-char beg)
+				       (current-column))))
+    (intero-async-call
+     'backend
+     (concat ":l " (intero-localize-path (intero-temp-file-name)))
+     (list :file-buffer (current-buffer)
+	   :line line
+	   :start start-column)
+     (lambda (state string)
+       (let* ((buffer (plist-get state :file-buffer))
+	      (line (plist-get state :line))
+	      (start (plist-get state :start))
+	      (expansion (intero-get-expansion-at-pos string buffer line start)))
+	 (when expansion
+	   (message (intero-fontify-expression expansion))))))))
 
 (defun intero-restart ()
   "Simply restart the process with the same configuration as before."
@@ -1661,6 +1698,9 @@ Automatically performs initial actions in SOURCE-BUFFER, if specified."
       (set-process-query-on-exit-flag process nil)
       (process-send-string process ":set -fobject-code\n")
       (process-send-string process ":set prompt \"\\4\"\n")
+      ;; The following settings give us expanded splices on load
+      (process-send-string process ":set -XTemplateHaskell\n")
+      (process-send-string process ":set -ddump-splices\n")
       (with-current-buffer buffer
         (erase-buffer)
         (setq intero-targets targets)

--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -402,7 +402,7 @@ Returns nil when unable to find definition."
 		(start (plist-get state :start))
 		(expansion (intero-get-expansion-at-pos string buffer line start)))
 	   (when expansion
-	     (message (intero-fontify-expression expansion))))))))
+	     (message "%s" (intero-fontify-expression expansion)))))))))
 
 (defun intero-restart ()
   "Simply restart the process with the same configuration as before."


### PR DESCRIPTION
Wrote functions to expand template haskell splice at point. point needs to be over the template haskell expression being expanded (rather than over parentheses or `$`). Think this is reasonable. Solves #310.

GHCi can be a bit awkward about column numbering, according to whether a template haskell expression is parenthesised or not (parentheses seem to +1 everything, if the "thing at point" is a parenthesised single character, only a single column is provided, rather than start and end...). I think I have this covered sensibly in the regex that grabs the expansion.

Overview of changes
* Load intero backend with `-ddump-splices` and `-XTemplateHaskell`.
* Add function to expand template haskell at point. This works by making the intero backend load the buffer's temporary file, and then regexing out the correct expansion.
* Shortcut `C-c C-e` bound to this for testing. Didn't set this with any particular thought (except e for expand), so might be worth setting to something else if there are strong opinions on the matter.

Tested over TRAMP (but not locally) with the following splices:
```
g = $template
g' = $f
g'' = $(f)
this = Just "filling a gap"; a = $f
h = $(template); g''' = $f
k = $(template' 3)
```
where
```
f :: Q Exp
f = [| \x -> x |]

template :: Q Exp
template = [| \x ->
               case x of
                 Nothing -> 0
                 Just _ -> 1 |]

template' :: Int -> Q Exp
template' x = [| \y -> x |]
```