### PR TITLE
Make the multiswitch buffer intelligible

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -433,7 +433,7 @@ If the problem persists, please report this as a bug!")))
          (available-targets (intero-get-targets))
          (targets (if available-targets
                       (intero-multiswitch
-                       "Targets:"
+                       "Set the targets to use for stack ghci:"
                        (mapcar (lambda (target)
                                  (list :key target
                                        :title target


### PR DESCRIPTION
"Targets:" told me 0 when I used this function.