### PR TITLE
Require Emacs 24.4 rather than 24.3, due to use of string-join

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -11,7 +11,7 @@
 ;; Created: 3rd June 2016
 ;; Version: 0.1.13
 ;; Keywords: haskell, tools
-;; Package-Requires: ((flycheck "0.25") (company "0.8") (emacs "24.3") (haskell-mode "13.0"))
+;; Package-Requires: ((flycheck "0.25") (company "0.8") (emacs "24.4") (haskell-mode "13.0"))
 
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Alternate fix would be to define an "intero-string-join" locally, or just use the classic `(mapconcat 'identity strings sep)`.