### PR TITLE
Intero is crashing for me at the moment, but that's another issue - this is about the error message i'm getting when it crashes.

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -1879,7 +1879,7 @@ The process ended. Here is the reason that Emacs gives us:
      "For troubleshooting purposes, here are the arguments used to launch intero:
 
 "
-     (format "  stack ghci %s"
+     (format "  stack %s"
              (combine-and-quote-strings intero-arguments))
      "
 


### PR DESCRIPTION
```
There were multiple candidates for the Cabal entry "test.hs" (/home/mark/projects/betterteam/.stack-work/downloaded/Ua0N4hDm1zuC/yesod-core/test.hs), picking /home/mark/projects/betterteam/.stack-work/downloaded/Ua0N4hDm1zuC/yesod-core/test/test.hs
The following GHC options are incompatible with GHCi and have not been passed to it: -Werror -threaded
Configuring GHCi with the following packages: thoth
/usr/lib/ghc/settings: openFile: does not exist (No such file or directory)

---

This is the buffer where Emacs talks to intero. It's normally hidden,
but a problem occcured.

TROUBLESHOOTING

It may be obvious if there is some text above this message
indicating a problem.

If you do not wish to use Intero for some projects, see
https://github.com/commercialhaskell/intero#whitelistingblacklisting-projects

The process ended. Here is the reason that Emacs gives us:

  exited abnormally with code 1

For troubleshooting purposes, here are the arguments used to launch intero:

  stack ghci ghci --with-ghc intero "--docker-run-args=--interactive=true --tty=false" --no-build --no-load --ghci-options -odir=/home/mark/projects/betterteam/.stack-work/intero/intero62760PL --ghci-options -hidir=/home/mark/projects/betterteam/.stack-work/intero/intero62760PL thoth

WHAT TO DO NEXT

If you fixed the problem, just kill this buffer, Intero will make
a fresh one and attempt to start the process automatically as
soon as you start editing code again.

If you are unable to fix the problem, just leave this buffer
around in Emacs and Intero will not attempt to start the process
anymore.

You can always run M-x intero-restart to make it try again.
```

"stack ghci ghci" is obviously wrong, and removing one ghci leaves us with 
a command line that gives me the same error.