### PR TITLE
More conventionally define (and name) the global mode

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -180,27 +180,26 @@ To use this, use the following mode hook:
 (define-key intero-mode-map (kbd "C-c C-r") 'intero-apply-suggestions)
 (define-key intero-mode-map (kbd "C-c C-e") 'intero-expand-splice-at-point)
 
+(define-minor-mode intero-global-mode
+  "Enable Intero on all Haskell mode buffers."
+  :global t
+  (if intero-global-mode
+      (add-hook 'haskell-mode-hook 'intero-mode)
+    (remove-hook 'haskell-mode-hook 'intero-mode))
+  (when (called-interactively-p 'interactive)
+    (message "Intero mode is now %s in all future Haskell buffers."
+             (if intero-global-mode
+                 "enabled" "disabled"))))
+
+(define-obsolete-function-alias 'global-intero-mode 'intero-global-mode)
+
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Global variables/state
-
-(defvar intero-global-mode nil
-  "Global mode is enabled?")
 
 (defvar intero-temp-file-buffer-mapping
   (make-hash-table)
   "A mapping from file names to buffers.")
-
-(defun global-intero-mode ()
-  "Enable Intero on all Haskell mode buffers."
-  (interactive)
-  (setq intero-global-mode (not intero-global-mode))
-  (if intero-global-mode
-      (add-hook 'haskell-mode-hook 'intero-mode)
-    (remove-hook 'haskell-mode-hook 'intero-mode))
-  (when (eq this-command 'global-intero-mode)
-    (message "Intero mode is now %s on all future Haskell buffers."
-             (if intero-global-mode
-                 "enabled" "disabled"))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Buffer-local variables/state


### PR DESCRIPTION
- `define-minor-mode` is a better way to declare the global minor mode, since it allows conventional toggling
- rename (but alias) the minor mode to consistently use the `intero-` prefix

Filing this as a pull request for review, rather than committing directly, though I think it's uncontroversial.

(Related: the conventional behaviour for a global minor mode like this would arguably be to enable `intero-mode` in all _pre-existing_ haskell buffers as well as future ones when enabled, and to disable it everywhere when disabled. Not sure whether that was considered in this case, or judged to be problematic/undesirable.)