### PR TITLE
Allow choosing which Stack executable to use

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -129,7 +129,6 @@ To use this, use the following mode hook:
   "Name or path to the Stack executable to use."
   :group 'intero
   :type 'string)
-(make-variable-buffer-local 'intero-stack-executable)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Modes


### PR DESCRIPTION
Resolves #393.

Use cases:

* testing different versions of Stack side-by-side,

* substituting `stack` with a small shim that uses a different resolver, e.g. Nix.