### PR TITLE
Customize intero-stack-executable-function instead of a variable

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -122,11 +122,16 @@ To use this, use the following mode hook:
   :group 'intero
   :type 'string)
 
-(defcustom intero-stack-executable
-  "stack"
-  "Name or path to the Stack executable to use."
+(defcustom intero-stack-executable-function
+  'intero-stack-executable-default
+  "The function used obtain the name or path of the Stack executable to use."
   :group 'intero
-  :type 'string)
+  :type '(radio (function-item intero-stack-executable-default)
+                (function :tag "Function")))
+
+(defun intero-stack-executable-default ()
+  "Use `stack' by default."
+  "stack")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Modes
@@ -265,7 +270,7 @@ This is slower, but will build required dependencies.")
 
 (defun intero-inherit-local-variables (buffer)
   "Make the current buffer inherit values of certain local variables from BUFFER."
-  (let ((variables '(intero-stack-executable
+  (let ((variables '(intero-stack-executable-function
                      intero-repl-no-build
                      intero-repl-no-load
                      ;; TODO: shouldn’t more of the above be here?
@@ -1102,7 +1107,7 @@ If PROMPT-OPTIONS is non-nil, prompt with an options list."
                     (buffer-local-value 'intero-repl-no-load backend-buffer)
                     nil)))
     (insert (propertize
-             (format "Starting:\n  %s ghci %s\n" intero-stack-executable
+             (format "Starting:\n  %s ghci %s\n" (funcall intero-stack-executable-function)
                      (combine-and-quote-strings arguments))
              'face 'font-lock-comment-face))
     (let* ((script-buffer
@@ -1118,7 +1123,7 @@ If PROMPT-OPTIONS is non-nil, prompt with an options list."
               (intero-localize-path (intero-buffer-file-name)))))
       (let ((process
              (get-buffer-process
-              (apply #'make-comint-in-buffer "intero" (current-buffer) intero-stack-executable nil "ghci"
+              (apply #'make-comint-in-buffer "intero" (current-buffer) (funcall intero-stack-executable-function) nil "ghci"
                      (append arguments
                              (list "--verbosity" "silent")
                              (list "--ghci-options"
@@ -1708,7 +1713,7 @@ Installing intero-%s automatically ...
 " intero-package-version))
       (redisplay)
       (cl-case (intero-call-process
-                intero-stack-executable nil (current-buffer) t "build"
+                (funcall intero-stack-executable-function) nil (current-buffer) t "build"
                 (with-current-buffer buffer
                   (let* ((cabal-file (intero-cabal-find-file))
                          (package-name (intero-package-name cabal-file)))
@@ -1762,7 +1767,7 @@ Automatically performs initial actions in SOURCE-BUFFER, if specified."
                       (when intero-debug
                         (message "Intero arguments: %s" (combine-and-quote-strings arguments)))
                       (message "Booting up intero ...")
-                      (apply #'start-file-process "stack" buffer intero-stack-executable
+                      (apply #'start-file-process "stack" buffer (funcall intero-stack-executable-function)
                              arguments))))
       (set-process-query-on-exit-flag process nil)
       (process-send-string process ":set -fobject-code\n")
@@ -1873,7 +1878,7 @@ This is a standard process sentinel function."
   "Return non-nil if intero (of the right version) is installed in the stack environment."
   (redisplay)
   (intero-with-temp-buffer
-    (if (= 0 (intero-call-process intero-stack-executable nil t nil "exec"
+    (if (= 0 (intero-call-process (funcall intero-stack-executable-function) nil t nil "exec"
                                   "--verbosity" "silent"
                                   "--" "intero" "--version"))
         (progn
@@ -1917,7 +1922,7 @@ The process ended. Here is the reason that Emacs gives us:
 
 "
      (format "  %s %s"
-             intero-stack-executable
+             (funcall intero-stack-executable-function)
              (combine-and-quote-strings intero-arguments))
      "
 
@@ -2011,7 +2016,7 @@ config exists."
     (setq intero-project-root
           (intero-with-temp-buffer
             (cl-case (save-excursion
-                       (intero-call-process intero-stack-executable nil
+                       (intero-call-process (funcall intero-stack-executable-function) nil
                                             (current-buffer)
                                             nil
                                             "path"
@@ -2029,7 +2034,7 @@ Otherwise, please report this as a bug!
 
 For debugging purposes, try running the following in your terminal:
 
-%s path --project-root" intero-stack-executable)
+%s path --project-root" (funcall intero-stack-executable-function))
                  nil))))))
 
 (defun intero-ghc-version ()
@@ -2039,7 +2044,7 @@ For debugging purposes, try running the following in your terminal:
         (setq intero-ghc-version
               (intero-with-temp-buffer
                 (cl-case (save-excursion
-                           (intero-call-process intero-stack-executable
+                           (intero-call-process (funcall intero-stack-executable-function)
                                                 nil (current-buffer) t "ghc" "--" "--numeric-version"))
                   (0
                    (buffer-substring (line-beginning-position) (line-end-position)))
@@ -2048,7 +2053,8 @@ For debugging purposes, try running the following in your terminal:
 (defun intero-get-targets ()
   "Get all available targets."
   (intero-with-temp-buffer
-    (cl-case (intero-call-process intero-stack-executable nil (current-buffer) t "ide" "targets")
+    (cl-case (intero-call-process (funcall intero-stack-executable-function)
+                                  nil (current-buffer) t "ide" "targets")
       (0
        (cl-remove-if-not
         (lambda (line)
@@ -2211,7 +2217,7 @@ automatically."
                     (setq intero-hoogle-port port)
                     (start-process "hoogle"
                                    buffer
-                                   intero-stack-executable
+                                   (funcall intero-stack-executable-function)
                                    "hoogle"
                                    "server"
                                    "--no-setup"
@@ -2265,14 +2271,16 @@ automatically."
 (defun intero-hoogle-ready-p ()
   "Is hoogle ready to be started?"
   (intero-with-temp-buffer
-    (cl-case (intero-call-process intero-stack-executable nil (current-buffer) t
+    (cl-case (intero-call-process (funcall intero-stack-executable-function)
+                                  nil (current-buffer) t
                                   "hoogle" "--no-setup" "--verbosity" "silent")
       (0 t))))
 
 (defun intero-hoogle-supported-p ()
   "Is the stack hoogle command supported?"
   (intero-with-temp-buffer
-    (cl-case (intero-call-process intero-stack-executable nil (current-buffer) t
+    (cl-case (intero-call-process (funcall intero-stack-executable-function)
+                                  nil (current-buffer) t
                                   "hoogle" "--help")
       (0 t))))
 
@@ -2448,7 +2456,7 @@ suggestions are available."
         (setq intero-extensions
               (split-string
                (shell-command-to-string
-                (concat intero-stack-executable
+                (concat (funcall intero-stack-executable-function)
                         " exec --verbosity silent -- ghc --supported-extensions")))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Sometimes, the exact path to the executable might not be known, and its name not present in user’s PATH. In such a case, the user would benefit from the possibility of defining their own function to determine that path programmatically.

One possible ‘improvement’ would be to:

```elisp
(defun intero--stack-executable ()
  (funcall intero-stack-executable-function))
```

… and use that everywhere, instead of `(funcal intero-stack-executable-function)`. But I didn’t want to introduce that initially, as another similar symbol might confuse users…

/cc @purcell

Related to #393.