### PR TITLE
Skip `installing\n` in (intero-installed-p)

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -1878,8 +1878,10 @@ This is a standard process sentinel function."
                                   "--" "intero" "--version"))
         (progn
           (goto-char (point-min))
-          ;; This skipping comes due to https://github.com/commercialhaskell/intero/pull/216/files
-          (when (looking-at "Intero ")
+          ;; This skipping comes due to
+          ;; • https://github.com/commercialhaskell/intero/pull/216/files
+          ;; • https://github.com/commercialhaskell/intero/pull/405
+          (when (looking-at "\\(installing\n\\)?Intero ")
             (goto-char (match-end 0)))
           ;;
           (if (string= (buffer-substring (point) (line-end-position))


### PR DESCRIPTION
When Nix is installing packages, it outputs phase headers to STDERR. This behavior cannot be suppressed even with `--quiet` and `--no-build-output`.

Each time `project.cabal` is changed, there will be one `installing\n` on STDERR for the first run of `nix-build` or `nix-shell`, coming from a file in the heart of Nixpkgs → https://github.com/NixOS/nixpkgs/blob/7daec8a234da5b097544dd4fb3fa1d2012870d08/pkgs/stdenv/generic/setup.sh#L827 — even with the strictest quietness chosen.

More details: https://github.com/michalrus/intero-nix-shim/issues/1

@purcell, could we have this little change?… :concerned: :pray: 

/cc @shlevy