### PR TITLE
Make :loc-at work with module imports (implements #181)

### DIFF
--- a/src/GhciFind.hs
+++ b/src/GhciFind.hs
@@ -243,7 +243,7 @@ findImportLoc infos info sl sc el ec =
      return (modinfoLocation importedModInfo)
 
 getModuleImportedAt :: ModInfo -> Int -> Int -> Int -> Int -> Maybe ModuleName
-getModuleImportedAt info sl sc el ec = unLoc <$> ideclName <$> unLoc <$> importDeclarationMaybe
+getModuleImportedAt info sl sc el ec = fmap (unLoc . ideclName . unLoc) importDeclarationMaybe
   where importDeclarationMaybe = listToMaybe $ filter isWithinRange (modinfoImports info)
         isWithinRange importDecl = containsSrcSpan sl sc el ec (getLoc $ ideclName $ unLoc importDecl)
 

--- a/src/GhciInfo.hs
+++ b/src/GhciInfo.hs
@@ -19,7 +19,6 @@ import qualified Data.Map.Strict as M
 import           Data.Maybe
 import           Data.Time
 import           Desugar
-import           FastString
 import           GHC
 import           GhcMonad
 import           GhciTypes
@@ -78,7 +77,7 @@ getModInfo :: (GhcMonad m) => ModuleName -> m ModInfo
 getModInfo name =
   do m <- getModSummary name
      p <- parseModule m
-     let location = getModuleLocation (parsedSource p) m
+     let location = getModuleLocation (parsedSource p)
      typechecked <- typecheckModule p
      let Just (_, imports, _, _) = renamedSource typechecked
      allTypes <- processAllTypeCheckedModule typechecked
@@ -86,13 +85,10 @@ getModInfo name =
      now <- liftIO getCurrentTime
      return (ModInfo m allTypes i now imports location)
 
-getModuleLocation :: ParsedSource -> ModSummary -> SrcSpan
-getModuleLocation pSource modSummary = case hsmodName (unLoc pSource) of
-                              Just located -> getLoc located
-                              Nothing -> fallbackLocation
-  where fallbackLocation = fromMaybe noSrcSpan (makeFileSrcSpan <$> ml_hs_file (ms_location modSummary))
-        makeFileSrcSpan filePath = mkSrcSpan (makeFileSrcLoc filePath) (makeFileSrcLoc filePath)
-        makeFileSrcLoc filePath = mkSrcLoc (mkFastString filePath) 0 0
+getModuleLocation :: ParsedSource -> SrcSpan
+getModuleLocation pSource = case hsmodName (unLoc pSource) of
+  Just located -> getLoc located
+  Nothing -> noSrcSpan
 
 -- | Get ALL source spans in the module.
 processAllTypeCheckedModule :: GhcMonad m

--- a/src/GhciTypes.hs
+++ b/src/GhciTypes.hs
@@ -23,7 +23,7 @@ data ModInfo =
            -- ^ Last time the module was updated.
           ,modinfoImports :: ![LImportDecl Name]
            -- ^ Import declarations within this module.
-          ,modinfoLocation :: SrcSpan
+          ,modinfoLocation :: !SrcSpan
            -- ^ The location of the module
           }
 

--- a/src/GhciTypes.hs
+++ b/src/GhciTypes.hs
@@ -23,6 +23,8 @@ data ModInfo =
            -- ^ Last time the module was updated.
           ,modinfoImports :: ![LImportDecl Name]
            -- ^ Import declarations within this module.
+          ,modinfoLocation :: SrcSpan
+           -- ^ The location of the module
           }
 
 -- | Type of some span of source code. Most of these fields are


### PR DESCRIPTION
This uses the existing import declarations from ModInfo. It also stores the location of the module in ModInfo. 

I'm not sure about handling of the locations as now there are three types of ranges (SrcSpan, SpanInfo and 4 Ints). 

It should implement #181.

Let me know what you think.