### PR TITLE
Touch before load

### DIFF
--- a/intero.cabal
+++ b/intero.cabal
@@ -63,6 +63,7 @@ executable intero
     GhciTypes
     GhciInfo
     GhciFind
+    GhciIO
   build-depends:
     base < 5,
     array,

--- a/src/GhciIO.hs
+++ b/src/GhciIO.hs
@@ -12,10 +12,6 @@ import qualified System.Win32 as Win32
 import System.Posix (touchFile)
 #endif
 
-#ifdef mingw32_HOST_OS
-import Data.Bits ((.&.))
-#endif
-
 {-| Touch a file, updating the access and modification times to the current time
 
     Creates an empty file if it does not exist

--- a/src/GhciIO.hs
+++ b/src/GhciIO.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE CPP #-}
+
+-- |
+
+module GhciIO (touchIfExists) where
+
+import System.Directory
+
+#ifdef mingw32_HOST_OS
+import qualified System.Win32 as Win32
+#else
+import System.Posix (touchFile)
+#endif
+
+#ifdef mingw32_HOST_OS
+import Data.Bits ((.&.))
+#endif
+
+{-| Touch a file, updating the access and modification times to the current time
+
+    Creates an empty file if it does not exist
+
+Copied from turtle.
+-}
+touchIfExists :: FilePath -> IO ()
+touchIfExists file = do
+    exists <- doesFileExist file
+    if exists
+#ifdef mingw32_HOST_OS
+        then do
+            handle <- Win32.createFile
+                file
+                Win32.gENERIC_WRITE
+                Win32.fILE_SHARE_NONE
+                Nothing
+                Win32.oPEN_EXISTING
+                Win32.fILE_ATTRIBUTE_NORMAL
+                Nothing
+            (creationTime, _, _) <- Win32.getFileTime handle
+            systemTime <- Win32.getSystemTimeAsFileTime
+            Win32.setFileTime handle creationTime systemTime systemTime
+#else
+        then touchFile file
+#endif
+        else pure ()

--- a/src/InteractiveUI.hs
+++ b/src/InteractiveUI.hs
@@ -26,6 +26,7 @@ module InteractiveUI (
 #include "HsVersions.h"
 
 -- Intero
+import           GhciIO
 #if __GLASGOW_HASKELL__ >= 800
 import           GHCi
 import           GHCi.RemoteTypes
@@ -1495,7 +1496,9 @@ loadModule :: [(FilePath, Maybe Phase)] -> InputT GHCi SuccessFlag
 loadModule fs = timeIt (loadModule' fs)
 
 loadModule_ :: [FilePath] -> InputT GHCi ()
-loadModule_ fs = loadModule (zip fs (repeat Nothing)) >> return ()
+loadModule_ fs = do
+  liftIO (mapM_ touchIfExists fs)
+  loadModule (zip fs (repeat Nothing)) >> return ()
 
 loadModule' :: [(FilePath, Maybe Phase)] -> InputT GHCi SuccessFlag
 loadModule' files = do


### PR DESCRIPTION
Fixes #143.

I copied the code from turtle. This function is present in System.Directory but only in a newer version than the range we support.

I've had successful builds on OS X, Linux and Windows for this code so it seems portable.

The code is very simple. Just touch each argument passed to `:load` before doing the load procedure. Nothing fancy. 