### PR TITLE
Cmd queue

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -225,6 +225,8 @@ and blacklist match, then the whitelist entry wins, and
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Buffer-local variables/state
 
+(defvar-local intero-worker-name nil
+  "Name of the current worker.")
 (defvar-local intero-callbacks (list)
   "List of callbacks waiting for output.
 LIST is a FIFO.")
@@ -2061,6 +2063,7 @@ Uses the directory of the current buffer for context."
         (get-buffer-create buffer-name)
       (intero-inherit-local-variables initial-buffer)
       (setq intero-package-name package-name)
+      (setq intero-worker-name worker)
       (cd default-directory)
       (current-buffer))))
 

--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -577,7 +577,7 @@ running context across :load/:reloads in Intero."
              :checker checker)
        (lambda (state)
          (with-current-buffer (plist-get state :file-buffer)
-           (intero-temp-file-name)))
+           (set-file-times (intero-temp-file-name))))
        (lambda (state string)
          (let ((compile-ok (string-match "OK, modules loaded: \\(.*\\)\\.$" string)))
            (with-current-buffer (plist-get state :file-buffer)


### PR DESCRIPTION
Sadly, like https://github.com/commercialhaskell/intero/pull/421, this doesn't work either.

Test: make a buffer with a warning. Tab enter twice at the end of the buffer. No warnings displayed.

Even though it writes the file just before running the `:l` and each `:l` is sent in isolation rather than all at once.

So it seems that in both cases, the modification time (I suppose at this resolution) is not enough for GHCi/intero to actually do a recompilation.

```
[Intero] -> :l /Users/chris/Emacs/packages/intero/.stack-work/intero/intero377CNO.hs
[Intero] <- [1 of 1] Compiling Demo             ( /Users/chris/Emacs/packages/intero/.stack-work/intero/intero377CNO.hs, /Users/chris/Emacs/packages/intero/.stack-work/intero/intero377p5I/Demo.o )

/Users/chris/Emacs/packages/intero/.stack-work/intero/intero377CNO.hs:5:1: Warning:
[Intero] <- 
    Top-level binding with no type signature: x :: Integer

/Users/chris/Emacs/packages/intero/.stack-work/intero/intero377CNO.hs:5:7: Warning:
    Defaulting the following constraint(s) to type ‘Integer’
      (Num a0) arising from a use of ‘*’
    In the expression:
[Intero] <-  1 * 2
    In an equation for ‘x’: x = 1 * 2
Ok, modules loaded: Demo.
Collecting type info for 1 module(s) ... 

/Users/chris/Emacs/packages/intero/.stack-work/intero/intero377CNO.hs:5:1: Warning:
    Top-level binding with no type signature: x :: Inte
[Intero] <- ger

/Users/chris/Emacs/packages/intero/.stack-work/intero/intero377CNO.hs:5:7: Warning:
    Defaulting the following constraint(s) to type ‘Integer’
      (Num a0) arising from a use of ‘*’
    In the expression: 1 * 2
    In an equation for ‘x’
[Intero] <- : x = 1 * 2

[Intero] -> :l /Users/chris/Emacs/packages/intero/.stack-work/intero/intero377CNO.hs
[Intero] <- Ok, modules loaded: Demo.

[Intero] -> :m + 
[Intero] <- 
```