### PR TITLE
Added Clang to nix packages.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -5,4 +5,4 @@ extra-deps: []
 flags: {}
 extra-package-dbs: []
 nix:
-  packages: [ ncurses ]
+  packages: [ ncurses clang ]


### PR DESCRIPTION
Appears this was missing as I couldn't compile the project without it.

Connected to this (and I don't actually know the answer), should stack.yaml be part of the tarball? I'm wondering because as a NixOS user when intero attempts to build itself it does it without honouring any of the nix options and then fails because there's no curses library available.