### PR TITLE
Improve auto complete at point

### DIFF
--- a/src/GhciMonad.hs
+++ b/src/GhciMonad.hs
@@ -123,7 +123,6 @@ data GHCiState = GHCiState
 
         -- stored state
         mod_infos :: !(Map ModuleName ModInfo),
-        rdrNamesInScope :: ![GHC.RdrName],
 
         ghci_work_directory :: FilePath,
             -- ^ Used to store the working directory associated with

--- a/src/GhciMonad.hs
+++ b/src/GhciMonad.hs
@@ -123,6 +123,7 @@ data GHCiState = GHCiState
 
         -- stored state
         mod_infos :: !(Map ModuleName ModInfo),
+        rdrNamesInScope :: ![GHC.RdrName],
 
         ghci_work_directory :: FilePath,
             -- ^ Used to store the working directory associated with

--- a/src/InteractiveUI.hs
+++ b/src/InteractiveUI.hs
@@ -561,7 +561,6 @@ interactiveUI config srcs maybe_exprs = do
                    short_help          = shortHelpText config,
                    long_help           = fullHelpText config,
                    mod_infos           = M.empty,
-                   rdrNamesInScope     = [],
                    ghci_work_directory = current_directory,
                    ghc_work_directory  = current_directory
                  }
@@ -649,10 +648,6 @@ runGHCi paths maybe_exprs = do
 
   -- reset line number
   getGHCiState >>= \st -> setGHCiState st{line_number=1}
-
-  -- Get the names in scope
-  names <- GHC.getRdrNamesInScope
-  modifyGHCiState (\s -> s { rdrNamesInScope = names })
 
   case maybe_exprs of
         Nothing ->
@@ -1563,11 +1558,10 @@ doLoad retain_context howmuch = do
       return ok
   case wasok of
     Succeeded -> do
-      names <- GHC.getRdrNamesInScope
       loaded <- getModuleGraph >>= filterM GHC.isLoaded . map GHC.ms_mod_name
       v <- lift (fmap mod_infos getGHCiState)
       !newInfos <- collectInfo v loaded
-      lift (modifyGHCiState (\s -> s { mod_infos = newInfos, rdrNamesInScope = names }))
+      lift (modifyGHCiState (\s -> s { mod_infos = newInfos }))
     _ -> return ()
   return wasok
 
@@ -2302,9 +2296,6 @@ setGHCContextFromGHCiState = do
         then iidecls ++ [implicitPreludeImport]
         else iidecls
     -- XXX put prel at the end, so that guessCurrentModule doesn't pick it up.
-  -- Get the names in scope
-  names <- GHC.getRdrNamesInScope
-  modifyGHCiState (\s -> s { rdrNamesInScope = names })
 
 -- -----------------------------------------------------------------------------
 -- Utils on InteractiveImport

--- a/src/InteractiveUI.hs
+++ b/src/InteractiveUI.hs
@@ -2938,7 +2938,7 @@ completeMacro = wrapIdentCompleter $ \w -> do
   return (filter (w `isPrefixOf`) (map cmdName cmds))
 
 completeIdentifier = wrapIdentCompleter $ \w -> do
-  rdrs <- fmap rdrNamesInScope getGHCiState
+  rdrs <- GHC.getRdrNamesInScope
   dflags <- GHC.getSessionDynFlags
   return (filter (w `isPrefixOf`) (map (showPpr dflags) rdrs))
 

--- a/src/InteractiveUI.hs
+++ b/src/InteractiveUI.hs
@@ -2929,7 +2929,7 @@ completeMacro = wrapIdentCompleter $ \w -> do
   return (filter (w `isPrefixOf`) (map cmdName cmds))
 
 completeIdentifier = wrapIdentCompleter $ \w -> do
-  rdrs <- GHC.getRdrNamesInScope
+  rdrs <- fmap rdrNamesInScope getGHCiState
   dflags <- GHC.getSessionDynFlags
   return (filter (w `isPrefixOf`) (map (showPpr dflags) rdrs))
 


### PR DESCRIPTION
Fixes https://github.com/commercialhaskell/intero/issues/441 in the local `stack build && exec intero` repl. I couldn't figure out how to test my local build as an intero-global-mode backend with emacs. 

With this removed, there are no uses of `rdrNamesInScope` in the entire project. 

    ~/programming/intero $ ag -a rdrNamesInScope
    src/InteractiveUI.hs
    564:                   rdrNamesInScope     = [],
    655:  modifyGHCiState (\s -> s { rdrNamesInScope = names })
    1570:      lift (modifyGHCiState (\s -> s { mod_infos = newInfos, rdrNamesInScope = names }))
    2307:  modifyGHCiState (\s -> s { rdrNamesInScope = names })

    src/GhciMonad.hs
    126:        rdrNamesInScope :: ![GHC.RdrName],

I think this field was meant to allow autocompletion in the main buffer of the `intero-global-mode` even when the modules don't compile (but did at one point). I would have tested how this pull request changes that, but I couldn't figure out how to. 