### PR TITLE
Fix REPL autocomplete

### DIFF
--- a/example.hs
+++ b/example.hs
@@ -1,0 +1,1 @@
+fail = 3 :: String

--- a/example.hs
+++ b/example.hs
@@ -1,1 +1,0 @@
-fail = 3 :: String

--- a/src/GhciMonad.hs
+++ b/src/GhciMonad.hs
@@ -123,7 +123,6 @@ data GHCiState = GHCiState
 
         -- stored state
         mod_infos :: !(Map ModuleName ModInfo),
-        rdrNamesInScope :: ![GHC.RdrName],
 
         ghci_work_directory :: FilePath,
             -- ^ Used to store the working directory associated with

--- a/src/InteractiveUI.hs
+++ b/src/InteractiveUI.hs
@@ -592,7 +592,6 @@ interactiveUI config srcs maybe_exprs = do
                    short_help          = shortHelpText config,
                    long_help           = fullHelpText config,
                    mod_infos           = M.empty,
-                   rdrNamesInScope     = [],
                    ghci_work_directory = current_directory,
                    ghc_work_directory  = current_directory
                  }
@@ -680,10 +679,6 @@ runGHCi paths maybe_exprs = do
 
   -- reset line number
   getGHCiState >>= \st -> setGHCiState st{line_number=1}
-
-  -- Get the names in scope
-  names <- GHC.getRdrNamesInScope
-  modifyGHCiState (\s -> s { rdrNamesInScope = names })
 
   case maybe_exprs of
         Nothing ->
@@ -1635,11 +1630,10 @@ doLoad retain_context howmuch = do
       return ok
   case wasok of
     Succeeded -> do
-      names <- GHC.getRdrNamesInScope
       loaded <- getModuleGraph >>= filterM GHC.isLoaded . map GHC.ms_mod_name
       v <- lift (fmap mod_infos getGHCiState)
       !newInfos <- collectInfo v loaded
-      lift (modifyGHCiState (\s -> s { mod_infos = newInfos, rdrNamesInScope = names }))
+      lift (modifyGHCiState (\s -> s { mod_infos = newInfos }))
     _ -> return ()
   return wasok
 
@@ -2386,9 +2380,6 @@ setGHCContextFromGHCiState = do
         then iidecls ++ [implicitPreludeImport]
         else iidecls
     -- XXX put prel at the end, so that guessCurrentModule doesn't pick it up.
-  -- Get the names in scope
-  names <- GHC.getRdrNamesInScope
-  modifyGHCiState (\s -> s { rdrNamesInScope = names })
 
 -- -----------------------------------------------------------------------------
 -- Utils on InteractiveImport

--- a/src/InteractiveUI.hs
+++ b/src/InteractiveUI.hs
@@ -3014,10 +3014,28 @@ completeMacro = wrapIdentCompleter $ \w -> do
   cmds <- liftIO $ readIORef macros_ref
   return (filter (w `isPrefixOf`) (map cmdName cmds))
 
-completeIdentifier = wrapIdentCompleter $ \w -> do
-  rdrs <- GHC.getRdrNamesInScope
-  dflags <- GHC.getSessionDynFlags
-  return (filter (w `isPrefixOf`) (map (showPpr dflags) rdrs))
+
+isSymbolChar :: Char -> Bool
+isSymbolChar c = not (c `elem` specials) && case generalCategory c of
+    MathSymbol              -> True
+    CurrencySymbol          -> True
+    ModifierSymbol          -> True
+    OtherSymbol             -> True
+    DashPunctuation         -> True
+    OtherPunctuation        -> not (c `elem` "'\"")
+    ConnectorPunctuation    -> c /= '_'
+    _                       -> False
+
+completeIdentifier line@(left, _) =
+  -- Note: `left` is a reversed input
+  case left of
+    (x:_) | isSymbolChar x -> wrapCompleter (specials ++ spaces) completeIdent line
+    _                      -> wrapIdentCompleter completeIdent line
+  where
+    completeIdent w = do
+      rdrs <- GHC.getRdrNamesInScope
+      dflags <- GHC.getSessionDynFlags
+      return (filter (w `isPrefixOf`) (map (showPpr dflags) rdrs))
 
 completeModule = wrapIdentCompleter $ \w -> do
   dflags <- GHC.getSessionDynFlags

--- a/src/InteractiveUI.hs
+++ b/src/InteractiveUI.hs
@@ -295,10 +295,12 @@ ghciCommands = [
 -- NOTE: in order for us to override the default correctly, any custom entry
 -- must be a SUBSET of word_break_chars.
 word_break_chars :: String
-word_break_chars = let symbols = "!#$%&*+/<=>?@\\^|-~"
-                       specials = "(),;[]`{}"
-                       spaces = " \t\n"
-                   in spaces ++ specials ++ symbols
+word_break_chars = spaces ++ specials ++ symbols
+
+symbols, specials, spaces :: String
+symbols = "!#$%&*+/<=>?@\\^|-~"
+specials = "(),;[]`{}"
+spaces = " \t\n"
 
 flagWordBreakChars :: String
 flagWordBreakChars = " \t\n"

--- a/src/InteractiveUI.hs
+++ b/src/InteractiveUI.hs
@@ -3022,7 +3022,7 @@ completeMacro = wrapIdentCompleter $ \w -> do
   return (filter (w `isPrefixOf`) (map cmdName cmds))
 
 completeIdentifier = wrapIdentCompleter $ \w -> do
-  rdrs <- fmap rdrNamesInScope getGHCiState
+  rdrs <- GHC.getRdrNamesInScope
   dflags <- GHC.getSessionDynFlags
   return (filter (w `isPrefixOf`) (map (showPpr dflags) rdrs))
 


### PR DESCRIPTION
A redo of my effort to fix https://github.com/commercialhaskell/intero/issues/441 ([original](https://github.com/commercialhaskell/intero/pull/442)).

There are two lists of scopes available in the code, `GHCiState` and `GHC.getRdrNamesInScope`. They start off the same. `GHCiState` does not change when the user adds new identifiers into the scope through let bindings in the repl, but if the user `:load`s a file with errors in it, `GHC.getRdrNamesInScope` is cleared. 

~~My proposed solution is to lazily combine the pros of each. I think the idea here is on target, but they style isn't very good yet.~~ Edit: solution changed with `git push --force` 