### PR TITLE
Fix repl autocomplete

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -808,24 +808,22 @@ CHECKER and BUFFER are added to each item parsed from STRING."
       (cl-destructuring-bind
           (beg end prefix _type) prefix-info
         (let* ((repl-buffer (current-buffer))
-               (proc (get-buffer-process (current-buffer)))
-               (output
-                (with-temp-buffer
-                  (comint-redirect-send-command-to-process
-                   (format ":complete repl %S" prefix) ;; command
-                   (current-buffer) ;; output buffer
-                   proc ;; target process
-                   nil  ;; echo
-                   t)   ;; no-display
-                  (while (not (with-current-buffer repl-buffer
-                                      comint-redirect-completed))
-                    (sleep-for 0.01))
-                  (let* ((completions (intero-completion-response-to-list (buffer-string)))
-                         (first-line (car completions)))
-                    (when (string-match "[^ ]* [^ ]* " first-line) ;; "2 2 :load src/"
-                      (setq first-line (replace-match "" nil nil first-line))
-                      (list (+ beg (length first-line)) end (cdr completions)))))))
-          output)))))
+               (proc (get-buffer-process (current-buffer))))
+          (with-temp-buffer
+            (comint-redirect-send-command-to-process
+             (format ":complete repl %S" prefix) ;; command
+             (current-buffer) ;; output buffer
+             proc ;; target process
+             nil  ;; echo
+             t)   ;; no-display
+            (while (not (with-current-buffer repl-buffer
+                          comint-redirect-completed))
+              (sleep-for 0.01))
+            (let* ((completions (intero-completion-response-to-list (buffer-string)))
+                   (first-line (car completions)))
+              (when (string-match "[^ ]* [^ ]* " first-line) ;; "2 2 :load src/"
+                (setq first-line (replace-match "" nil nil first-line))
+                (list (+ beg (length first-line)) end (cdr completions))))))))))
 
 (defun intero-text-from-prompt-to-point ()
   "Return the text from this buffer from the prompt up to right behind the point."

--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -801,7 +801,7 @@ CHECKER and BUFFER are added to each item parsed from STRING."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Traditional completion-at-point function
 
-(defun intero-repl-tab-completion-at-point ()
+(defun intero-repl-completion-at-point ()
   "A (blocking) function suitable for use in `completion-at-point-functions'."
   (let ((prefix-info (intero-text-from-prompt-to-point)))
     (when prefix-info
@@ -1296,10 +1296,9 @@ function is subsequently applied to each line, once."
   (add-hook 'comint-output-filter-functions
             'intero-linkify-process-output
             t t)
-  (local-set-key (kbd "TAB") 'complete-symbol)
   (setq-local comint-prompt-read-only t)
   (setq-local company-idle-delay nil)
-  (add-hook 'completion-at-point-functions 'intero-repl-tab-completion-at-point nil t)
+  (add-hook 'completion-at-point-functions 'intero-repl-completion-at-point nil t)
   (add-to-list (make-local-variable 'company-backends) 'intero-company)
   (company-mode))
 

--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -1297,7 +1297,6 @@ function is subsequently applied to each line, once."
             'intero-linkify-process-output
             t t)
   (setq-local comint-prompt-read-only t)
-  (setq-local company-idle-delay nil)
   (add-hook 'completion-at-point-functions 'intero-repl-completion-at-point nil t)
   (add-to-list (make-local-variable 'company-backends) 'intero-company)
   (company-mode))

--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -831,7 +831,7 @@ CHECKER and BUFFER are added to each item parsed from STRING."
                           (setq first-line (replace-match "" nil nil first-line))
                           (list (+ beg (length first-line)) end (cdr completions))))
                     ; old intero builds interfere with :complete
-                    (message "Repl autocomplete not finishing. Try deleting .stackwork")))))
+                    (message "Comint repl autocomplete timed out")))))
           output)))))
 
 (defun intero-text-from-prompt-to-point ()

--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -809,27 +809,28 @@ CHECKER and BUFFER are added to each item parsed from STRING."
           (beg end prefix _type) prefix-info
         (let* ((proc (get-buffer-process (current-buffer)))
                (time0 (float-time))
-               (output (with-temp-buffer
+               (output
+                (with-temp-buffer
                   (comint-redirect-send-command-to-process
                    (format ":complete repl %S" prefix) ;; command
                    (current-buffer) ;; output buffer
                    proc ;; target process
                    nil  ;; echo
                    t)   ;; no-display
-                (while (and (string-empty-p (buffer-string))
-                            (< (- (float-time) time0) 5))
+                  (while (and (string-empty-p (buffer-string))
+                              (< (- (float-time) time0) 5))
                     (sleep-for 0.01))
-                (if (not (string-empty-p (buffer-string)))
-                  (let* ((completions (intero-completion-response-to-list (buffer-string)))
-                         (first-line (car completions)))
-                    (when (string-match "[^ ]* [^ ]* " first-line) ;; "2 2 :load src/"
-                      (setq first-line (replace-match "" nil nil first-line))
-                      (list (+ beg (length first-line)) end (cdr completions))))
-                 ; old intero bins don't do :complete right
-                (message "Repl complete lagging. Try deleting .stackwork")))))
-         (message (format "thing: %S" output))
-         (message (format "curbf: %S" (current-buffer)))
-         output)))))
+                  (if (not (string-empty-p (buffer-string)))
+                      (let* ((completions (intero-completion-response-to-list (buffer-string)))
+                             (first-line (car completions)))
+                        (when (string-match "[^ ]* [^ ]* " first-line) ;; "2 2 :load src/"
+                          (setq first-line (replace-match "" nil nil first-line))
+                          (list (+ beg (length first-line)) end (cdr completions))))
+                                        ; old intero bins don't do :complete right
+                    (message "Repl complete lagging. Try deleting .stackwork")))))
+          (message (format "thing: %S" output))
+          (message (format "curbf: %S" (current-buffer)))
+          output)))))
 
 (defun intero-text-from-prompt-to-point ()
   "Return the text from this buffer from the prompt up to right behind the point."

--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -151,7 +151,6 @@ To use this, use the following mode hook:
   (if intero-mode
       (progn
         (intero-flycheck-enable)
-        (add-hook 'completion-at-point-functions 'intero-completion-at-point nil t)
         (add-to-list (make-local-variable 'company-backends) 'intero-company)
         (company-mode)
         (unless eldoc-documentation-function
@@ -802,7 +801,7 @@ CHECKER and BUFFER are added to each item parsed from STRING."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Traditional completion-at-point function
 
-(defun intero-completion-at-point ()
+(defun intero-repl-tab-completion-at-point ()
   "A (blocking) function suitable for use in `completion-at-point-functions'."
   (let ((prefix-info (text-from-prompt-to-point)))
     (when prefix-info
@@ -1298,7 +1297,7 @@ function is subsequently applied to each line, once."
             'intero-linkify-process-output
             t t)
   (setq-local comint-prompt-read-only t)
-  (add-hook 'completion-at-point-functions 'intero-completion-at-point nil t)
+  (add-hook 'completion-at-point-functions 'intero-repl-tab-completion-at-point nil t)
   (add-to-list (make-local-variable 'company-backends) 'intero-company)
   (company-mode))
 

--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -803,7 +803,7 @@ CHECKER and BUFFER are added to each item parsed from STRING."
 
 (defun intero-repl-tab-completion-at-point ()
   "A (blocking) function suitable for use in `completion-at-point-functions'."
-  (let ((prefix-info (text-from-prompt-to-point)))
+  (let ((prefix-info (intero-text-from-prompt-to-point)))
     (when prefix-info
       (cl-destructuring-bind
           (beg end prefix _type) prefix-info
@@ -827,7 +827,7 @@ CHECKER and BUFFER are added to each item parsed from STRING."
               (setq first-line (replace-match "" nil nil first-line))
               (list (+ beg (length first-line)) end (cdr completions)))))))))
 
-(defun text-from-prompt-to-point ()
+(defun intero-text-from-prompt-to-point ()
   "Return the text from this buffer from the prompt up to right behind the point."
   (let ((beg (save-excursion (intero-repl-beginning-of-line) (point)))
         (end (point)))

--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -1296,7 +1296,9 @@ function is subsequently applied to each line, once."
   (add-hook 'comint-output-filter-functions
             'intero-linkify-process-output
             t t)
+  (local-set-key (kbd "TAB") 'complete-symbol)
   (setq-local comint-prompt-read-only t)
+  (setq-local company-idle-delay nil)
   (add-hook 'completion-at-point-functions 'intero-repl-tab-completion-at-point nil t)
   (add-to-list (make-local-variable 'company-backends) 'intero-company)
   (company-mode))

--- a/src/GhciMonad.hs
+++ b/src/GhciMonad.hs
@@ -123,7 +123,6 @@ data GHCiState = GHCiState
 
         -- stored state
         mod_infos :: !(Map ModuleName ModInfo),
-        rdrNamesInScope :: ![GHC.RdrName],
 
         ghci_work_directory :: FilePath,
             -- ^ Used to store the working directory associated with

--- a/src/InteractiveUI.hs
+++ b/src/InteractiveUI.hs
@@ -592,7 +592,6 @@ interactiveUI config srcs maybe_exprs = do
                    short_help          = shortHelpText config,
                    long_help           = fullHelpText config,
                    mod_infos           = M.empty,
-                   rdrNamesInScope     = [],
                    ghci_work_directory = current_directory,
                    ghc_work_directory  = current_directory
                  }
@@ -680,10 +679,6 @@ runGHCi paths maybe_exprs = do
 
   -- reset line number
   getGHCiState >>= \st -> setGHCiState st{line_number=1}
-
-  -- Get the names in scope
-  names <- GHC.getRdrNamesInScope
-  modifyGHCiState (\s -> s { rdrNamesInScope = names })
 
   case maybe_exprs of
         Nothing ->
@@ -1635,11 +1630,10 @@ doLoad retain_context howmuch = do
       return ok
   case wasok of
     Succeeded -> do
-      names <- GHC.getRdrNamesInScope
       loaded <- getModuleGraph >>= filterM GHC.isLoaded . map GHC.ms_mod_name
       v <- lift (fmap mod_infos getGHCiState)
       !newInfos <- collectInfo v loaded
-      lift (modifyGHCiState (\s -> s { mod_infos = newInfos, rdrNamesInScope = names }))
+      lift (modifyGHCiState (\s -> s { mod_infos = newInfos }))
     _ -> return ()
   return wasok
 
@@ -2386,9 +2380,6 @@ setGHCContextFromGHCiState = do
         then iidecls ++ [implicitPreludeImport]
         else iidecls
     -- XXX put prel at the end, so that guessCurrentModule doesn't pick it up.
-  -- Get the names in scope
-  names <- GHC.getRdrNamesInScope
-  modifyGHCiState (\s -> s { rdrNamesInScope = names })
 
 -- -----------------------------------------------------------------------------
 -- Utils on InteractiveImport

--- a/src/InteractiveUI.hs
+++ b/src/InteractiveUI.hs
@@ -294,11 +294,12 @@ ghciCommands = [
 --
 -- NOTE: in order for us to override the default correctly, any custom entry
 -- must be a SUBSET of word_break_chars.
-word_break_chars :: String
-word_break_chars = let symbols = "!#$%&*+/<=>?@\\^|-~"
-                       specials = "(),;[]`{}"
-                       spaces = " \t\n"
-                   in spaces ++ specials ++ symbols
+word_break_chars = spaces ++ specials ++ symbols
+
+symbols, specials, spaces :: String
+symbols = "!#$%&*+/<=>?@\\^|-~"
+specials = "(),;[]`{}"
+spaces = " \t\n"
 
 flagWordBreakChars :: String
 flagWordBreakChars = " \t\n"

--- a/src/InteractiveUI.hs
+++ b/src/InteractiveUI.hs
@@ -294,6 +294,7 @@ ghciCommands = [
 --
 -- NOTE: in order for us to override the default correctly, any custom entry
 -- must be a SUBSET of word_break_chars.
+word_break_chars :: String
 word_break_chars = spaces ++ specials ++ symbols
 
 symbols, specials, spaces :: String

--- a/src/InteractiveUI.hs
+++ b/src/InteractiveUI.hs
@@ -3022,7 +3022,7 @@ completeMacro = wrapIdentCompleter $ \w -> do
   return (filter (w `isPrefixOf`) (map cmdName cmds))
 
 completeIdentifier = wrapIdentCompleter $ \w -> do
-  rdrs <- fmap rdrNamesInScope getGHCiState
+  rdrs <- GHC.getRdrNamesInScope
   dflags <- GHC.getSessionDynFlags
   return (filter (w `isPrefixOf`) (map (showPpr dflags) rdrs))
 


### PR DESCRIPTION
I was frustrated that intero auto-complete suggestions did not update as I added new identifiers. The solution given at issue https://github.com/commercialhaskell/intero/issues/245 sends `:complete repl` calls to an untouched back-end instance of intero, instead of the visible instance that has all of the identifiers defined.

I changed `intero-completion-at-point` to send commands to the visible instance so tab completion works like the native version.

I also fixed a related issue in the intero repl backend where running `:complete repl "<"` lists every single identifier in scope instead of just those that start with `<` in https://github.com/commercialhaskell/intero/commit/68b41c66596bc98bd533c4c1ed6f2602bcef3399

I would like constructive feedback on `intero-completion-at-point` (now named `intero-repl-tab-completion-at-point`). I think my ad-hoc async call should be integrated with `intero-async-call`. 

I assume people working in the repl would not need to use tab to indent so in https://github.com/commercialhaskell/intero/commit/24dc2be401c823102f069e40aeb89bc75f560d09 I bound tab directly to `'complete-symbol` in the repl mode. Is that appropriate?

---------------------------------------------
Steps to run emacs with a locally installed intero repl: 
1. Compile intero from source
2. Copy `intero/elisp/intero.el` to `~/.emacs.d/elpa/intero-<number>/intero.el` (or its equivalent)
3. Make a new project, set the resolver to lts-5.6
4. `stack setup` and `stack build` new project
5. Open project source file in emacs with intero, load repl, and exit (if you get a warning that mentions ignored, `chmod 700 testproject/.stackwork/intero`)
6. Copy intero binary to replace `testproject/.stackwork/install/<platform>/lts-5.6/7.10.3/bin/intero` (or its equivalent)