### PR TITLE
Fix tests on Windows

### DIFF
--- a/intero.cabal
+++ b/intero.cabal
@@ -111,4 +111,5 @@ test-suite intero-test
     process,
     transformers,
     directory,
-    regex-compat
+    regex-compat,
+    filepath

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -9,6 +9,7 @@ import Control.Monad (forM_)
 import Data.Char
 import System.IO
 import System.IO.Temp
+import System.FilePath ((</>))
 import System.Process
 import Test.Hspec
 import Text.Regex
@@ -66,7 +67,7 @@ basics =
           (do reply <- withIntero [] (\_ repl -> repl ":i Nothing")
               shouldBe
                 (subRegex (mkRegex "Data.Maybe") reply "GHC.Base")
-                "data Maybe a = Nothing | ... \t-- Defined in ‘GHC.Base’\n")
+                "data Maybe a = Nothing | ... \t-- Defined in `GHC.Base'\n")
         it ":k Just" (eval ":k Maybe" "Maybe :: * -> *\n"))
 
 -- | Loading files and seeing the results.
@@ -334,7 +335,7 @@ definition =
           (locAtMultiple
              [("X.hs", "import Y"), ("Y.hs", "module Y where")]
              (1, 8, 1, 9, "Y")
-             (unlines ["./Y.hs:(1,8)-(1,9)"]))
+             (unlines ["." </> "Y.hs:(1,8)-(1,9)"]))
         issue
           "To unexported thing"
           "https://github.com/commercialhaskell/intero/issues/98"

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -11,6 +11,7 @@ import System.IO
 import System.IO.Temp
 import System.FilePath ((</>))
 import System.Process
+import System.Info (os)
 import Test.Hspec
 import Text.Regex
 
@@ -67,8 +68,16 @@ basics =
           (do reply <- withIntero [] (\_ repl -> repl ":i Nothing")
               shouldBe
                 (subRegex (mkRegex "Data.Maybe") reply "GHC.Base")
-                "data Maybe a = Nothing | ... \t-- Defined in `GHC.Base'\n")
+                ("data Maybe a = Nothing | ... \t-- Defined in " ++ (quote "GHC.Base") ++ "\n"))
         it ":k Just" (eval ":k Maybe" "Maybe :: * -> *\n"))
+  where
+    quote s = opQuote : s ++ [clQuote]
+    opQuote = case os of
+        "mingw32" -> '`'
+        _ -> '‘'
+    clQuote = case os of
+        "mingw32" -> '\''
+        _ -> '’'
 
 -- | Loading files and seeing the results.
 load :: Spec


### PR DESCRIPTION
Tests should run correctly on Windows now.

One of the solutions in particular relies on System.Info.os, as it turns out different outputs are generated depending on the OS. Other solutions for that include things like CPP, which I'm not sure are desirable at all.