### PR TITLE
Fix cache invalidation strawman

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -1622,7 +1622,7 @@ path."
     temporary-file-directory))
 
 (defun intero-temp-file-name (&optional buffer)
-  "Return the name of a temp file containing an up-to-date copy of BUFFER's contents."
+  "Return the name of a temp file pertaining to BUFFER."
   (with-current-buffer (or buffer (current-buffer))
     (or intero-temp-file-name
         (progn (setq intero-temp-file-name

--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -70,7 +70,7 @@
   :group 'haskell)
 
 (defcustom intero-package-version
-  "0.1.21"
+  "0.1.22"
   "Package version to auto-install.
 
 This version does not necessarily have to be the latest version
@@ -661,13 +661,12 @@ running context across :load/:reloads in Intero."
            (staging-file (intero-localize-path (intero-staging-file-name)))
            (temp-file (intero-localize-path (intero-temp-file-name)))
            (hash (intero-check-calculate-hash)))
-      ;; We queue up to mv the staging file to the target temp
-      ;; file and touch it to update its modified time.
+      ;; We queue up to :move the staging file to the target temp
+      ;; file, which also updates its modified time.
       (intero-async-call
        'backend
-       (format ":!mv \"%s\" \"%s\"; touch \"%s\""
+       (format ":move \"%s\" \"%s\""
                staging-file
-               temp-file
                temp-file))
       ;; We load up the target temp file, which has only been updated
       ;; by the copy above.
@@ -705,7 +704,7 @@ running context across :load/:reloads in Intero."
       ;; changed, if the timestamp is less than 1 second.
       (intero-async-call
        'backend
-       ":!sleep 1"))))
+       ":sleep 1"))))
 
 (flycheck-define-generic-checker 'intero
   "A syntax and type checker for Haskell using an Intero worker

--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -661,14 +661,14 @@ running context across :load/:reloads in Intero."
            (staging-file (intero-localize-path (intero-staging-file-name)))
            (temp-file (intero-localize-path (intero-temp-file-name)))
            (hash (intero-check-calculate-hash)))
-      ;; We queue up a copy of a staging file to the target temp
-      ;; file. Once that's copied, we remove the staging file.
+      ;; We queue up to mv the staging file to the target temp
+      ;; file and touch it to update its modified time.
       (intero-async-call
        'backend
-       (format ":!cp \"%s\" \"%s\"; rm \"%s\""
+       (format ":!mv \"%s\" \"%s\"; touch \"%s\""
                staging-file
                temp-file
-               staging-file))
+               temp-file))
       ;; We load up the target temp file, which has only been updated
       ;; by the copy above.
       (intero-async-call

--- a/intero.cabal
+++ b/intero.cabal
@@ -1,7 +1,7 @@
 name:
   intero
 version:
-  0.1.21
+  0.1.22
 synopsis:
   Complete interactive development program for Haskell
 license:


### PR DESCRIPTION
@purcell The infamous flycheck disappearing error messages error persisted since we fixed it. At the time I was so busy I just accepted it. It's starting to become a problem for me. I ended up developing a habit of hitting RET just to make the flycheck errors update.

![screenflow](https://user-images.githubusercontent.com/11019/30056262-f55c9d2a-9229-11e7-988e-5bea8370b044.gif)

Are you not reproducing this? The elisp-side caching we did doesn't work. 

Meanwhile I've come up with an alternative solution:

The problem with the historical approach is that Emacs Lisp writes to the temp file NOW. For the duration of one second, any subsequent updates to the module are ignored by GHCi. And, of course, our code doesn't rewrite the file if the contents didn't change. So there's nothing to invalidate the file afterwards anyway. But even if we did update the file, it'd be ignored for 1 second. So we need a way to sleep between commands without blocking Emacs or having async command queue issues.

Instead, we already have an ordered queue in Intero's query/reply REPL. So we can write the file contents to `STAGING` immediately, and then queue up:

1. We queue up a command for intero to copy it to the temp file when it gets to it in its own time. After copying STAGING to TEMP, that updates TEMP's contents and modified time. We delete STAGING.
2. We queue up :load to load that TEMP file. 
3. Finally, we queue up a third item: sleep for one second. This prevents step (1) from running until after one second has passed.

We retain proper ordering, all calls by flycheck return results pertaining to that exact change, and we don't block the Emacs UI at all with the sleep. We sleep afterwards so that the user doesn't have to wait for the first set of results to come back, just subsequent ones.

**Summary**

I'm going to test this out for a few days, but I have confidence in its dumb simplicity that it's going to solve it. The problem for distributing this would be that I use POSIX commands; so it may rather be better to add these commands to the Intero as `:copy-and-check` and `:sleep`.