### PR TITLE
Document that `C-c C-k` quits the suggestion pane

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -2396,7 +2396,7 @@ Each option is a plist of (:key :default :title) wherein:
                        (lambda (&rest ignore)
                          (abort-recursive-edit))
                        "C-c C-k")
-        (widget-insert (propertize " to quit without applying choices.\n\n" 'face 'font-lock-comment-face))
+        (widget-insert (propertize " to cancel.\n\n" 'face 'font-lock-comment-face))
         (let* ((me (current-buffer))
                (choices (mapcar (lambda (option)
                                   (append option (list :value (plist-get option :default))))

--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -2391,7 +2391,12 @@ Each option is a plist of (:key :default :title) wherein:
                        (lambda (&rest ignore)
                          (exit-recursive-edit))
                        "C-c C-c")
-        (widget-insert (propertize " to apply these choices.\n\n" 'face 'font-lock-comment-face))
+        (widget-insert (propertize " to apply these choices, or hit " 'face 'font-lock-comment-face))
+        (widget-create 'push-button :notify
+                       (lambda (&rest ignore)
+                         (abort-recursive-edit))
+                       "C-c C-k")
+        (widget-insert (propertize " to quit without applying choices.\n\n" 'face 'font-lock-comment-face))
         (let* ((me (current-buffer))
                (choices (mapcar (lambda (option)
                                   (append option (list :value (plist-get option :default))))


### PR DESCRIPTION
We used to be able to quit the suggestion pane with `C-g`, but that
was removed in 397e5c8258c97be8e2abb1d34526219fc816ca86. The the `C-g`
was intuitive to me, but `C-c C-k` was not -- I had to look at the Git
log to figure it out -- so I thought it would be helpful to document
it. My next guess after `C-g` was `q`, which is also more intuitive
than `C-c C-k` to me.

I did not test this change, since I don't know how to run Emacs
packages from source.