### PR TITLE
Add `defcustom` to disable `pop-to-repl` on `C-c C-l`.

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -131,8 +131,7 @@ To use this, use the following mode hook:
 
 (defcustom intero-pop-to-repl
   t
-  "Wether to call `pop-to-buffer' when code is sent to the
-  REPL."
+  "When non-nil, pop to REPL when code is sent to it."
   :group 'intero
   :type 'boolean)
 

--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -129,6 +129,13 @@ To use this, use the following mode hook:
   :group 'intero
   :type 'string)
 
+(defcustom intero-pop-to-repl
+  t
+  "Wether to call `pop-to-buffer' when code is sent to the
+  REPL."
+  :group 'intero
+  :type 'boolean)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Modes
 
@@ -1109,7 +1116,8 @@ be activated after evaluation.  PROMPT-OPTIONS are passed to
     `(let ((,repl-buffer (intero-repl-buffer ,prompt-options t)))
        (with-current-buffer ,repl-buffer
          ,@body)
-       (pop-to-buffer ,repl-buffer))))
+       (when intero-pop-to-repl
+         (pop-to-buffer ,repl-buffer)))))
 
 (defun intero-repl-load (&optional prompt-options)
   "Load the current file in the REPL.


### PR DESCRIPTION
This pull request adds the option to disable `pop-to-buffer` when evaluating code either via `intero-repl-eval-region` or `intero-repl-load` (or any other function that uses `intero-with-repl-buffer`). This was done purely out of personal need as my other REPL environment (clojure / cider) doesn't pop up the repl buffer on evaluate :-) 

One could also implement a more sophisticated approach, either allowing full customization of what function is used for showing the buffer, or by allowing users to choose if they want to jump to the buffer based on some other predicate, for example the prefix-arg. 

This minimal approach is just a first step (and to probe if you're interested in this kind of improvements to `intero-mode`).


Cheers!