### PR TITLE
Enable -fdefer-type-errors on start-up

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -1318,6 +1318,7 @@ stack's default)."
             (with-current-buffer (find-file-noselect (intero-make-temp-file "intero-script"))
               (insert ":set prompt \"\"
 :set -fbyte-code
+:set -fdefer-type-errors
 :set prompt \"\\4 \"
 ")
               (basic-save-buffer)
@@ -2010,6 +2011,7 @@ Uses the default stack config file, or STACK-YAML file if given."
                              arguments))))
       (set-process-query-on-exit-flag process nil)
       (process-send-string process ":set -fobject-code\n")
+      (process-send-string process ":set -fdefer-type-errors\n")
       (process-send-string process ":set prompt \"\\4\"\n")
       (with-current-buffer buffer
         (erase-buffer)

--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -761,7 +761,7 @@ CHECKER and BUFFER are added to each item parsed from STRING."
         (forward-line -1))
       (delete-dups
        (if found-error-as-warning
-           (remove-if (lambda (msg) (eq 'warning (flycheck-error-level msg))) messages)
+           (cl-remove-if (lambda (msg) (eq 'warning (flycheck-error-level msg))) messages)
          messages)))))
 
 (defconst intero-error-regexp-alist


### PR DESCRIPTION
See https://github.com/commercialhaskell/intero/issues/476#issuecomment-348467874 for detailed explanation.

I'm going to spend the day on this branch; if it doesn't cause any regressions in behavior (or bad performance), I'll merge to master.

If you want to test this out now, just run `killall intero` and start the processes up again.