### PR TITLE
Handle a null (buffer-file-name) when white/black listing

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -202,9 +202,10 @@ To use this, use the following mode hook:
 
 (defun intero-directories-contain-file (file dirs)
   "Return non-nil if FILE is contained in at least one of DIRS."
-  (cl-some (lambda (directory)
-             (file-in-directory-p file directory))
-           dirs))
+  (and (not (null file))
+       (cl-some (lambda (directory)
+                  (file-in-directory-p file directory))
+                dirs)))
 
 (defun intero-mode-maybe ()
   "Enable `intero-mode' in all Haskell mode buffers.


### PR DESCRIPTION
I ran into trouble when exporting some Org files that had Haskell ~src~ blocks since I switched to white-listing.