### PR TITLE
Do not sleep-for in with-current-buffer

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -1889,8 +1889,8 @@ yaml config to use, or stack's default when nil."
      result
      (lambda (result reply)
        (setf (car result) reply)))
-    (with-current-buffer (intero-buffer worker)
-      (while (not (null intero-callbacks))
+    (let ((buffer (intero-buffer worker)))
+      (while (not (null (buffer-local-value 'intero-callbacks buffer)))
         (sleep-for 0.0001)))
     (car result)))
 


### PR DESCRIPTION
Deferred executors will run in wrong buffer context.