### PR TITLE
#474 Only ":reload" file if it is equal to "intero-repl-last-loaded"

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -1133,10 +1133,16 @@ If PROMPT-OPTIONS is non-nil, prompt with an options list."
   (save-buffer)
   (let ((file (intero-localize-path (intero-buffer-file-name))))
     (intero-with-repl-buffer prompt-options
-      (comint-simple-send
-       (get-buffer-process (current-buffer))
-       (concat ":load " file))
-      (setq intero-repl-last-loaded file))))
+      (if (or (not intero-repl-last-loaded)
+	      (not (equal file intero-repl-last-loaded)))
+	  (progn
+	    (comint-simple-send
+	     (get-buffer-process (current-buffer))
+	     (concat ":load " file))
+	    (setq intero-repl-last-loaded file))
+	(comint-simple-send
+	 (get-buffer-process (current-buffer))
+	 ":reload")))))
 
 (defun intero-repl-eval-region (begin end &optional prompt-options)
   "Evaluate the code in region from BEGIN to END in the REPL.


### PR DESCRIPTION
This checks if the path of the current file is equal to the content of
"intero-repl-load". If the paths are equal, the file is only reloaded, which
skips recompilation of unchanged dependency modules.

This is faster and a bit more convenient in larger projects.

This would resolve enhancement request #474