### PR TITLE
Revert "#474 Only ":reload" file if it is equal to "intero-repl-last-loaded""

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -1133,16 +1133,10 @@ If PROMPT-OPTIONS is non-nil, prompt with an options list."
   (save-buffer)
   (let ((file (intero-localize-path (intero-buffer-file-name))))
     (intero-with-repl-buffer prompt-options
-      (if (or (not intero-repl-last-loaded)
-	      (not (equal file intero-repl-last-loaded)))
-	  (progn
-	    (comint-simple-send
-	     (get-buffer-process (current-buffer))
-	     (concat ":load " file))
-	    (setq intero-repl-last-loaded file))
-	(comint-simple-send
-	 (get-buffer-process (current-buffer))
-	 ":reload")))))
+      (comint-simple-send
+       (get-buffer-process (current-buffer))
+       (concat ":load " file))
+      (setq intero-repl-last-loaded file))))
 
 (defun intero-repl-eval-region (begin end &optional prompt-options)
   "Evaluate the code in region from BEGIN to END in the REPL.


### PR DESCRIPTION
Reverts commercialhaskell/intero#498

If the module isn't successfully loaded, ghci just says:
```
 Ok, modules loaded: none.
 Ok, modules loaded: none.
 Ok, modules loaded: none.
 Ok, modules loaded: none.
```