### PR TITLE
Support asynchronous read-only commands

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -260,6 +260,21 @@ and blacklist match, then the whitelist entry wins, and
   "List of callbacks waiting for output.
 LIST is a FIFO.")
 
+(defvar-local intero-async-network-cmd nil
+  "Command to send to the async network process when we connect.")
+
+(defvar-local intero-async-network-connected nil
+  "Did we successfully connect to the intero service?")
+
+(defvar-local intero-async-network-state nil
+  "State to pass to the callback once we get a response.")
+
+(defvar-local intero-async-network-worker nil
+  "The worker we're associated with.")
+
+(defvar-local intero-async-network-callback nil
+  "Callback to call when the connection is closed.")
+
 (defvar-local intero-arguments (list)
   "Arguments used to call the stack process.")
 
@@ -294,6 +309,9 @@ This is slower, but will build required dependencies.")
 
 (defvar-local intero-starting nil
   "When non-nil, indicates that the intero process starting up.")
+
+(defvar-local intero-service-port nil
+  "Port that the intero process is listening on for asynchronous commands.")
 
 (defvar-local intero-hoogle-port nil
   "Port that hoogle server is listening on.")
@@ -1675,7 +1693,7 @@ x:\\foo\\bar (i.e., Windows)."
 
 (defun intero-get-all-types ()
   "Get all types in all expressions in all modules."
-  (intero-blocking-call 'backend ":all-types"))
+  (intero-blocking-network-call 'backend ":all-types"))
 
 (defun intero-get-type-at (beg end)
   "Get the type at the given region denoted by BEG and END."
@@ -1684,10 +1702,17 @@ x:\\foo\\bar (i.e., Windows)."
                       result)
         (progn (flycheck-buffer)
                (message "No type information yet, compiling module ...")
-               (intero-get-type-at-helper beg end))
+               (intero-get-type-at-helper-process beg end))
       result)))
 
 (defun intero-get-type-at-helper (beg end)
+  (replace-regexp-in-string
+   "\n$" ""
+   (intero-blocking-network-call
+    'backend
+    (intero-format-get-type-at beg end))))
+
+(defun intero-get-type-at-helper-process (beg end)
   (replace-regexp-in-string
    "\n$" ""
    (intero-blocking-call
@@ -1698,7 +1723,7 @@ x:\\foo\\bar (i.e., Windows)."
   "Call CONT with type of the region denoted by BEG and END.
 CONT is called within the current buffer, with BEG, END and the
 type as arguments."
-  (intero-async-call
+  (intero-async-network-call
    'backend
    (intero-format-get-type-at beg end)
    (list :cont cont
@@ -1765,10 +1790,28 @@ type as arguments."
                       result)
         (progn (flycheck-buffer)
                (message "No location information yet, compiling module ...")
-               (intero-get-loc-at-helper beg end))
+               (intero-get-loc-at-helper-process beg end))
       result)))
 
 (defun intero-get-loc-at-helper (beg end)
+  "Make the blocking call to the process."
+  (replace-regexp-in-string
+   "\n$" ""
+   (intero-blocking-network-call
+    'backend
+    (format ":loc-at %S %d %d %d %d %S"
+            (intero-localize-path (intero-temp-file-name))
+            (save-excursion (goto-char beg)
+                            (line-number-at-pos))
+            (save-excursion (goto-char beg)
+                            (1+ (current-column)))
+            (save-excursion (goto-char end)
+                            (line-number-at-pos))
+            (save-excursion (goto-char end)
+                            (1+ (current-column)))
+            (buffer-substring-no-properties beg end)))))
+
+(defun intero-get-loc-at-helper-process (beg end)
   "Make the blocking call to the process."
   (replace-regexp-in-string
    "\n$" ""
@@ -1793,10 +1836,28 @@ type as arguments."
                       result)
         (progn (flycheck-buffer)
                (message "No use information yet, compiling module ...")
-               (intero-get-uses-at-helper beg end))
+               (intero-get-uses-at-helper-process beg end))
       result)))
 
 (defun intero-get-uses-at-helper (beg end)
+  "Return usage list for identifier denoted by BEG and END."
+  (replace-regexp-in-string
+   "\n$" ""
+   (intero-blocking-network-call
+    'backend
+    (format ":uses %S %d %d %d %d %S"
+            (intero-localize-path (intero-temp-file-name))
+            (save-excursion (goto-char beg)
+                            (line-number-at-pos))
+            (save-excursion (goto-char beg)
+                            (1+ (current-column)))
+            (save-excursion (goto-char end)
+                            (line-number-at-pos))
+            (save-excursion (goto-char end)
+                            (1+ (current-column)))
+            (buffer-substring-no-properties beg end)))))
+
+(defun intero-get-uses-at-helper-process (beg end)
   "Return usage list for identifier denoted by BEG and END."
   (replace-regexp-in-string
    "\n$" ""
@@ -1818,7 +1879,7 @@ type as arguments."
   "Get completions and send to SOURCE-BUFFER.
 Prefix is marked by positions BEG and END.  Completions are
 passed to CONT in SOURCE-BUFFER."
-  (intero-async-call
+  (intero-async-network-call
    'backend
    (format ":complete-at %S %d %d %d %d %S"
            (intero-localize-path (intero-temp-file-name))
@@ -1911,6 +1972,76 @@ yaml config to use, or stack's default when nil."
       (while (not (null (buffer-local-value 'intero-callbacks buffer)))
         (sleep-for 0.0001)))
     (car result)))
+
+(defun intero-blocking-network-call (worker cmd)
+  "Send WORKER the command string CMD via the network and block pending its result."
+  (let ((result (list nil)))
+    (intero-async-network-call
+     worker
+     cmd
+     result
+     (lambda (result reply)
+       (setf (car result) reply)))
+    (while (eq (car result) nil)
+      (sleep-for 0.0001))
+    (car result)))
+
+(defun intero-async-network-call (worker cmd &optional state callback)
+  "Send WORKER the command string CMD, via a network connection.
+The result, along with the given STATE, is passed to CALLBACK
+as (CALLBACK STATE REPLY)."
+  (let ((buffer (intero-buffer worker)))
+    (if (and buffer (process-live-p (get-buffer-process buffer)))
+        (with-current-buffer buffer
+          (if intero-service-port
+              (let* ((buffer (generate-new-buffer (format " intero-network:%S" worker)))
+                     (process
+                      (make-network-process
+                       :name (format "%S" worker)
+                       :buffer buffer
+                       :host 'local
+                       :service intero-service-port
+                       :family 'ipv4
+                       :nowait t
+                       :noquery t
+                       :sentinel 'intero-network-call-sentinel)))
+                (with-current-buffer buffer
+                  (setq intero-async-network-cmd cmd)
+                  (setq intero-async-network-state state)
+                  (setq intero-async-network-worker worker)
+                  (setq intero-async-network-callback callback)))
+            (progn (when intero-debug (message "No `intero-service-port', falling back ..."))
+                   (intero-async-call worker cmd state callback))))
+      (error "Intero process is not running: run M-x intero-restart to start it"))))
+
+(defun intero-network-call-sentinel (process event)
+  (with-current-buffer (process-buffer process)
+    (if (string= "open\n" event)
+        (progn
+          (when intero-debug (message "Connected to service, sending %S" intero-async-network-cmd))
+          (setq intero-async-network-connected t)
+          (if intero-async-network-cmd
+              (process-send-string process (concat intero-async-network-cmd "\n"))
+            (delete-process process)))
+      (progn
+        (if intero-async-network-connected
+            (when intero-async-network-callback
+              (when intero-debug (message "Calling callback with %S" (buffer-string)))
+              (funcall intero-async-network-callback
+                       intero-async-network-state
+                       (buffer-string)))
+          ;; We didn't successfully connect, so let's fallback to the
+          ;; process pipe.
+          (when intero-async-network-callback
+            (when intero-debug (message "Failed to connect, falling back ... "))
+            (setq intero-async-network-callback nil)
+            (intero-async-call
+             intero-async-network-worker
+             intero-async-network-cmd
+             intero-async-network-state
+             intero-async-network-callback)))
+        ;; In any case we clean up the connection.
+        (delete-process process)))))
 
 (defun intero-async-call (worker cmd &optional state callback)
   "Send WORKER the command string CMD.
@@ -2051,10 +2182,12 @@ Uses the default stack config file, or STACK-YAML file if given."
         (setq intero-callbacks
               (list (list (cons source-buffer
                                 buffer)
-                          (lambda (buffers _msg)
+                          (lambda (buffers msg)
                             (let ((source-buffer (car buffers))
                                   (process-buffer (cdr buffers)))
                               (with-current-buffer process-buffer
+                                (when (string-match "^Intero-Service-Port: \\([0-9]+\\)\n" msg)
+                                  (setq intero-service-port (string-to-number (match-string 1 msg))))
                                 (setq-local intero-starting nil))
                               (when source-buffer
                                 (with-current-buffer source-buffer

--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -70,7 +70,7 @@
   :group 'haskell)
 
 (defcustom intero-package-version
-  "0.1.24"
+  "0.1.25"
   "Package version to auto-install.
 
 This version does not necessarily have to be the latest version

--- a/intero.cabal
+++ b/intero.cabal
@@ -80,7 +80,9 @@ executable intero
     transformers,
     syb,
     containers,
-    time
+    time,
+    network,
+    random
 
   if impl(ghc>=8.0.1)
     build-depends:

--- a/intero.cabal
+++ b/intero.cabal
@@ -1,7 +1,7 @@
 name:
   intero
 version:
-  0.1.24
+  0.1.25
 synopsis:
   Complete interactive development program for Haskell
 license:

--- a/src/InteractiveUI.hs
+++ b/src/InteractiveUI.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE MagicHash #-}
@@ -52,6 +53,7 @@ import           GhciTags
 import           Debugger
 
 -- The GHC interface
+import Data.IORef
 import           DynFlags
 import           GhcMonad ( modifySession )
 import qualified GHC
@@ -105,12 +107,14 @@ import           Util
 
 -- Haskell Libraries
 import           System.Console.Haskeline as Haskeline
-
+import Network.Socket
+import qualified Network
+import Network.BSD
 import           Control.Applicative hiding (empty)
 import           Control.Monad as Monad
 import           Control.Monad.Trans.Class
 import           Control.Monad.IO.Class
-import           Control.Concurrent (threadDelay)
+import           Control.Concurrent (threadDelay, forkIO)
 #if MIN_VERSION_directory(1,2,3)
 import           Data.Time (getCurrentTime)
 #endif
@@ -121,7 +125,7 @@ import           Data.Char
 import           Data.Function
 import           Data.IORef ( IORef, readIORef, writeIORef )
 import Data.List ( find, group, intercalate, intersperse, isPrefixOf, nub,
-                   partition, sort, sortBy )
+                   partition, sort, sortBy)
 import           Data.Maybe
 #if __GLASGOW_HASKELL__ >= 802
 import qualified Data.Set as Set
@@ -281,17 +285,27 @@ ghciCommands = [
   ("step",      keepGoing stepCmd,              completeIdentifier),
   ("steplocal", keepGoing stepLocalCmd,         completeIdentifier),
   ("stepmodule",keepGoing stepModuleCmd,        completeIdentifier),
-  ("type",      keepGoing' typeOfExpr,          completeExpression),
-  ("type-at",   keepGoing' typeAt,              noCompletion),
-  ("all-types", keepGoing' allTypes,            noCompletion),
-  ("uses",      keepGoing' findAllUses,         noCompletion),
-  ("loc-at",    keepGoing' locationAt,          noCompletion),
-  ("complete-at", keepGoing' completeAt,          noCompletion),
+  ("type",      keepGoing' (lifted typeOfExpr),          completeExpression),
+  ("type-at",   keepGoing' (lifted typeAt),              noCompletion),
+  ("all-types", keepGoing' (lifted allTypes),            noCompletion),
+  ("uses",      keepGoing' (lifted findAllUses),         noCompletion),
+  ("loc-at",    keepGoing' (lifted locationAt),          noCompletion),
+  ("complete-at", keepGoing' (lifted completeAt),          noCompletion),
   ("trace",     keepGoing traceCmd,             completeExpression),
   ("undef",     keepGoing undefineMacro,        completeMacro),
   ("unset",     keepGoing unsetOptions,         completeSetOptions)
   ]
+  where lifted m = \str -> lift (m stdout str)
 
+
+readOnlyCommands :: [(String, Handle -> String -> GHCi ())]
+readOnlyCommands =
+  [ ("type-at", typeAt)
+  , ("all-types", allTypes)
+  , ("uses", findAllUses)
+  , ("loc-at", locationAt)
+  , ("complete-at", completeAt)
+  ]
 
 -- We initialize readline (in the interactiveUI function) to use
 -- word_break_chars as the default set of completion word break characters.
@@ -578,7 +592,7 @@ interactiveUI config srcs maybe_exprs = do
    default_editor <- liftIO $ findEditor
    current_directory <- liftIO $ getCurrentDirectory
 
-   startGHCi (runGHCi srcs maybe_exprs)
+   ref <- liftIO $newIORef
         GHCiState{ progname            = default_progname,
                    GhciMonad.args      = default_args,
                    prompt              = defPrompt config,
@@ -603,8 +617,72 @@ interactiveUI config srcs maybe_exprs = do
                    ghci_work_directory = current_directory,
                    ghc_work_directory  = current_directory
                  }
+   -- Start the GHCI interactive main loop. This loop handles all
+   -- types of commands, including loading modules and modifying the
+   -- GHCi state.
+   startGHCi (do runServer
+                 runGHCi srcs maybe_exprs)
+             ref
 
-   return ()
+runServer :: GHCi ()
+runServer = do
+  sock <-
+    liftIO
+      (withSocketsDo
+         (do sock <- listenOnLoopback
+             port <- fmap fromIntegral (socketPort sock) :: IO Int
+             putStrLn ("Intero-Service-Port: " ++ show port)
+             return sock))
+  GhciMonad.reifyGHCi
+    (\state -> do
+       _ <-
+         forkIO
+           (let loop = do
+                  (h, _, _) <- Network.accept sock
+                  hSetBuffering h NoBuffering
+                  _ <-
+                    forkIO
+                      (Exception.finally
+                         (do str <-
+                               fmap
+                                 (reverse . dropWhile isSpace . reverse)
+                                 (hGetLine h)
+                             -- putStrLn ("Got line: " ++ str)
+                             GhciMonad.reflectGHCi
+                               state
+                               (do let (cmd, rest) = break isSpace str
+                                       args = dropWhile isSpace rest
+                                   case lookup
+                                          (dropWhile (== ':') cmd)
+                                          readOnlyCommands of
+                                     Just c
+                                       -- liftIO (hPutStrLn h "Found command, running ...")
+                                      -> do
+                                       _ <- c h args
+                                       -- liftIO (hPutStrLn h "Command ran.")
+                                       pure ()
+                                     Nothing -> do
+                                       liftIO (hPutStrLn h "No such command!")
+                                       pure ())
+                             return ())
+                         (hClose h))
+                  loop
+            in loop)
+       return ())
+
+listenOnLoopback :: IO Socket
+listenOnLoopback = do
+  proto <- getProtocolNumber "tcp"
+  bracketOnError
+    (socket AF_INET Stream proto)
+    close
+    (\sock -> do
+       setSocketOption sock ReuseAddr 1
+       setSocketOption sock UseLoopBack 1
+       address <- getHostByName "127.0.0.1"
+       bind sock (SockAddrInet aNY_PORT (hostAddress address))
+       listen sock maxListenQueue
+       return sock)
 
 withGhcAppData :: (FilePath -> IO a) -> IO a -> IO a
 withGhcAppData right left = do
@@ -697,24 +775,28 @@ runGHCi paths maybe_exprs = do
           do
             -- enter the interactive loop
             runGHCiInput $ runCommands $ nextInputLine show_prompt is_tty
-        Just exprs -> do
-            -- just evaluate the expression we were given
-            enqueueCommands exprs
-            let hdle e = do st <- getGHCiState
-                            -- flush the interpreter's stdout/stderr on exit (#3890)
-                            flushInterpBuffers
-                            -- Jump through some hoops to get the
-                            -- current progname in the exception text:
-                            -- <progname>: <exception>
-                            liftIO $ withProgName (progname st)
-                                   $ topHandler e
-                                   -- this used to be topHandlerFastExit, see #2228
-            runInputTWithPrefs defaultPrefs defaultSettings $ do
-                -- make `ghc -e` exit nonzero on invalid input, see Trac #7962
-                runCommands' hdle (Just $ hdle (toException $ ExitFailure 1) >> return ()) (return Nothing)
+        Just exprs ->
+          runSingleInput (\hdle -> Just $ hdle (toException $ ExitFailure 1) >> return ()) exprs
 
   -- and finally, exit
   liftIO $ when (verbosity dflags > 0) $ putStrLn "Leaving GHCi."
+
+runSingleInput :: ((SomeException -> GHCi b) -> Maybe (GHCi ())) -> [String] -> GHCi ()
+runSingleInput errorHandler exprs = do
+  -- just evaluate the expression we were given
+  enqueueCommands exprs
+  let hdle e = do st <- getGHCiState
+                  -- flush the interpreter's stdout/stderr on exit (#3890)
+                  flushInterpBuffers
+                  -- Jump through some hoops to get the
+                  -- current progname in the exception text:
+                  -- <progname>: <exception>
+                  liftIO $ withProgName (progname st)
+                         $ topHandler e
+                         -- this used to be topHandlerFastExit, see #2228
+  runInputTWithPrefs defaultPrefs defaultSettings $ do
+      -- make `ghc -e` exit nonzero on invalid input, see Trac #7962
+      runCommands' hdle (errorHandler hdle) (return Nothing)
 
 runGHCiInput :: InputT GHCi a -> GHCi a
 runGHCiInput f = do
@@ -1156,7 +1238,7 @@ toBreakIdAndLocation (Just inf) = do
 
 printStoppedAtBreakInfo :: Resume -> [Name] -> GHCi ()
 printStoppedAtBreakInfo res names = do
-  printForUser $ ptext (sLit "Stopped at") <+>
+  printForUser stdout $ ptext (sLit "Stopped at") <+>
     ppr (GHC.resumeSpan res)
   --  printTypeOfNames session names
   let namesSorted = sortBy compareNames names
@@ -1281,8 +1363,8 @@ withSandboxOnly :: String -> GHCi () -> GHCi ()
 withSandboxOnly cmd this = do
    dflags <- getDynFlags
    if not (gopt Opt_GhciSandbox dflags)
-      then printForUser (text cmd <+>
-                         ptext (sLit "is not supported with -fno-ghci-sandbox"))
+      then printForUser stdout (text cmd <+>
+                                ptext (sLit "is not supported with -fno-ghci-sandbox"))
       else this
 
 -----------------------------------------------------------------------------
@@ -1796,8 +1878,9 @@ modulesLoadedMsg ok mods = do
 -----------------------------------------------------------------------------
 -- :type
 
-typeOfExpr :: String -> InputT GHCi ()
-typeOfExpr str
+typeOfExpr :: Handle -> String -> GHCi ()
+typeOfExpr
+   h str
   = handleSourceError GHC.printException
   $ do
 #if __GLASGOW_HASKELL__ >= 802
@@ -1805,51 +1888,51 @@ typeOfExpr str
 #else
        ty <- GHC.exprType str
 #endif
-       printForUser $ sep [text str, nest 2 (dcolon <+> pprTypeForUser ty)]
+       printForUser h $ sep [text str, nest 2 (dcolon <+> pprTypeForUser ty)]
 
 -----------------------------------------------------------------------------
 -- :type-at
 
-typeAt :: String -> InputT GHCi ()
-typeAt str =
+typeAt :: Handle -> String -> GHCi ()
+typeAt h str =
   handleSourceError
     GHC.printException
     (case parseSpan str of
-       Left err -> liftIO (putStr err)
+       Left err -> liftIO (hPutStrLn h err)
        Right (fp,sl,sc,el,ec,sample) ->
-         do infos <- fmap mod_infos (lift getGHCiState)
+         do infos <- fmap mod_infos getGHCiState
             result <- findType infos fp sample sl sc el ec
             case result of
-              FindTypeFail err -> liftIO (putStrLn err)
+              FindTypeFail err -> liftIO (hPutStrLn h err)
               FindType info' ty ->
-                printForUserModInfo
+                printForUserModInfo h
                   (modinfoInfo info')
                   (sep [text sample,nest 2 (dcolon <+> ppr ty)])
               FindTyThing info' tything ->
-                printForUserModInfo (modinfoInfo info')
-                                    (pprTyThing' tything))
+                printForUserModInfo h (modinfoInfo info')
+                                      (pprTyThing' tything))
 
 -----------------------------------------------------------------------------
 -- :uses
 
-findAllUses :: String -> InputT GHCi ()
-findAllUses str =
+findAllUses :: Handle -> String -> GHCi ()
+findAllUses h str =
   handleSourceError GHC.printException $
   case parseSpan str of
-    Left err -> liftIO (putStr err)
+    Left err -> liftIO (hPutStrLn h err)
     Right (fp,sl,sc,el,ec,sample) ->
-      do infos <- fmap mod_infos (lift getGHCiState)
+      do infos <- fmap mod_infos getGHCiState
          result <- findNameUses infos fp sample sl sc el ec
          case result of
-           Left err -> liftIO (putStrLn err)
+           Left err -> liftIO (hPutStrLn h  err)
            Right uses ->
              forM_ uses
                    (\sp ->
                       case sp of
                         RealSrcSpan rs ->
-                          liftIO (putStrLn (showSpan rs))
+                          liftIO (hPutStrLn h  (showSpan rs))
                         UnhelpfulSpan fs ->
-                          liftIO (putStrLn (unpackFS fs)))
+                          liftIO (hPutStrLn h  (unpackFS fs)))
   where showSpan span' =
           unpackFS (srcSpanFile span') ++
           ":(" ++
@@ -1865,11 +1948,11 @@ findAllUses str =
 -----------------------------------------------------------------------------
 -- :all-types
 
-allTypes :: String -> InputT GHCi ()
-allTypes _ =
+allTypes :: Handle -> String -> GHCi ()
+allTypes h _ =
   handleSourceError
     GHC.printException
-    (do infos <- fmap mod_infos (lift getGHCiState)
+    (do infos <- fmap mod_infos getGHCiState
         forM_ (M.elems infos)
               (\mi ->
                  forM_ (modinfoSpans mi) (printSpan mi)))
@@ -1881,7 +1964,7 @@ allTypes _ =
                    Nothing -> return ()
                    Just ty ->
                      liftIO
-                       (putStrLn
+                       (hPutStrLn h
                           (concat [fp ++":"
                                    -- GHC exposes a 1-based column number because reasons.
                                   ,"(" ++ show sl ++ "," ++ show (1+sc)  ++ ")-(" ++
@@ -1900,22 +1983,22 @@ allTypes _ =
 -----------------------------------------------------------------------------
 -- :loc-at
 
-locationAt :: String -> InputT GHCi ()
-locationAt str =
+locationAt :: Handle -> String -> GHCi ()
+locationAt h str =
   handleSourceError GHC.printException $
   case parseSpan str of
-    Left err -> liftIO (putStr err)
+    Left err -> liftIO (hPutStrLn h  err)
     Right (fp,sl,sc,el,ec,sample) ->
-      do infos <- fmap mod_infos (lift getGHCiState)
+      do infos <- fmap mod_infos getGHCiState
          result <- findLoc infos fp sample sl sc el ec
          case result of
-           Left err -> liftIO (putStrLn err)
+           Left err -> liftIO (hPutStrLn h  err)
            Right sp ->
              case sp of
                RealSrcSpan rs ->
-                 liftIO (putStrLn (showSpan rs))
+                 liftIO (hPutStrLn h  (showSpan rs))
                UnhelpfulSpan fs ->
-                 liftIO (putStrLn (unpackFS fs))
+                 liftIO (hPutStrLn h  (unpackFS fs))
   where showSpan span' =
           unpackFS (srcSpanFile span')  ++ ":(" ++
           show (srcSpanStartLine span')  ++ "," ++
@@ -1927,18 +2010,18 @@ locationAt str =
 -----------------------------------------------------------------------------
 -- :complete-at
 
-completeAt :: String -> InputT GHCi ()
-completeAt str =
+completeAt :: Handle -> String -> GHCi ()
+completeAt h str =
   handleSourceError GHC.printException $
   case parseSpan str of
-    Left err -> liftIO (putStr err)
+    Left err -> liftIO (hPutStrLn h  err)
     Right (fp,sl,sc,el,ec,sample) | not (null str) ->
-      do infos <- fmap mod_infos (lift getGHCiState)
+      do infos <- fmap mod_infos getGHCiState
          result <- findCompletions infos fp sample sl sc el ec
          case result of
            Left err -> error err
            Right completions' ->
-             liftIO (mapM_ putStrLn completions')
+             liftIO (mapM_ (hPutStrLn h ) completions')
     _ -> return ()
 
 -----------------------------------------------------------------------------
@@ -1984,8 +2067,8 @@ kindOfType norm str
   = handleSourceError GHC.printException
   $ do
        (ty, kind) <- GHC.typeKind norm str
-       printForUser $ vcat [ text str <+> dcolon <+> pprTypeForUser kind
-                           , ppWhen norm $ equals <+> ppr ty ]
+       printForUser stdout $ vcat [ text str <+> dcolon <+> pprTypeForUser kind
+                                  , ppWhen norm $ equals <+> ppr ty ]
 
 
 -----------------------------------------------------------------------------
@@ -2624,8 +2707,8 @@ setStop str@(c:_) | isDigit c
        st <- getGHCiState
        let old_breaks = breaks st
        if all ((/= nm) . fst) old_breaks
-              then printForUser (text "Breakpoint" <+> ppr nm <+>
-                                 text "does not exist")
+              then printForUser stdout (text "Breakpoint" <+> ppr nm <+>
+                                        text "does not exist")
               else do
        let new_breaks = map fn old_breaks
            fn (i,loc) | i == nm   = (i,loc { onBreakCmd = dropWhile isSpace rest })
@@ -2881,17 +2964,17 @@ showBindings = do
 
 
 printTyThing :: TyThing -> GHCi ()
-printTyThing tyth = printForUser (pprTyThing' tyth)
+printTyThing tyth = printForUser stdout (pprTyThing' tyth)
 
 showBkptTable :: GHCi ()
 showBkptTable = do
   st <- getGHCiState
-  printForUser $ prettyLocations (breaks st)
+  printForUser stdout $ prettyLocations (breaks st)
 
 showContext :: GHCi ()
 showContext = do
    resumes <- GHC.getResumeContext
-   printForUser $ vcat (map pp_resume (reverse resumes))
+   printForUser stdout $ vcat (map pp_resume (reverse resumes))
   where
    pp_resume res =
         ptext (sLit "--> ") <> text (GHC.resumeStmt res)
@@ -3187,8 +3270,8 @@ printCmd  = pprintCommand True False
 forceCmd  = pprintCommand False True
 
 pprintCommand :: Bool -> Bool -> String -> GHCi ()
-pprintCommand bind force str = do
-  pprintClosureCommand bind force str
+pprintCommand b force str = do
+  pprintClosureCommand b force str
 
 stepCmd :: String -> GHCi ()
 stepCmd arg = withSandboxOnly ":step" $ step arg
@@ -3295,7 +3378,8 @@ historyCmd arg
                  pans <- mapM GHC.getHistorySpan took
                  let nums  = map (printf "-%-3d:") [(1::Int)..]
                      names = map GHC.historyEnclosingDecls took
-                 printForUser (vcat(zipWith3
+                 printForUser stdout
+                              (vcat(zipWith3
                                  (\x y z -> x <+> y <+> z)
                                  (map text nums)
                                  (map (bold . hcat . punctuate colon . map text) names)
@@ -3313,7 +3397,7 @@ backCmd = noArgs $ withSandboxOnly ":back" $ do
 #else
   (names, _, pan, _) <- GHC.back 1
 #endif
-  printForUser $ ptext (sLit "Logged breakpoint at") <+> ppr pan
+  printForUser stdout $ ptext (sLit "Logged breakpoint at") <+> ppr pan
   printTypeOfNames names
    -- run the command set with ":set stop <cmd>"
   st <- getGHCiState
@@ -3326,9 +3410,9 @@ forwardCmd = noArgs $ withSandboxOnly ":forward" $ do
 #else
   (names, ix, pan) <- GHC.forward
 #endif
-  printForUser $ (if (ix == 0)
-                    then ptext (sLit "Stopped at")
-                    else ptext (sLit "Logged breakpoint at")) <+> ppr pan
+  printForUser stdout $ (if (ix == 0)
+                           then ptext (sLit "Stopped at")
+                           else ptext (sLit "Logged breakpoint at")) <+> ppr pan
   printTypeOfNames names
    -- run the command set with ":set stop <cmd>"
   st <- getGHCiState
@@ -3366,7 +3450,7 @@ breakSwitch (arg1:rest)
             UnhelpfulLoc _ ->
                 noCanDo name $ text "can't find its location: " <> ppr loc
        where
-          noCanDo n why = printForUser $
+          noCanDo n why = printForUser stdout $
                 text "cannot set breakpoint on " <> ppr n <> text ": " <> why
 
 breakByModule :: Module -> [String] -> GHCi ()
@@ -3404,14 +3488,14 @@ findBreakAndSet md lookupTickTree = do
                              , breakTick = tick
                              , onBreakCmd = ""
                              }
-               printForUser $
+               printForUser stdout $
                   text "Breakpoint " <> ppr nm <>
                   if alreadySet
                      then text " was already set at " <> ppr pan
                      else text " activated at " <> ppr pan
             else do
-            printForUser $ text "Breakpoint could not be activated at"
-                                 <+> ppr pan
+            printForUser stdout $ text "Breakpoint could not be activated at"
+                                        <+> ppr pan
 
 -- When a line number is specified, the current policy for choosing
 -- the best breakpoint is this:
@@ -3490,7 +3574,7 @@ listCmd' "" = do
    mb_span <- lift getCurrentBreakSpan
    case mb_span of
       Nothing ->
-          printForUser $ text "Not stopped at a breakpoint; nothing to list"
+          printForUser stdout $ text "Not stopped at a breakpoint; nothing to list"
       Just (RealSrcSpan pan) ->
           listAround pan True
       Just pan@(UnhelpfulSpan _) ->
@@ -3502,8 +3586,8 @@ listCmd' "" = do
                                       [] -> text "rerunning with :trace,"
                                       _ -> empty
                             doWhat = traceIt <+> text ":back then :list"
-                        printForUser (text "Unable to list source for" <+>
-                                      ppr pan
+                        printForUser stdout (text "Unable to list source for" <+>
+                                             ppr pan
                                    $$ text "Try" <+> doWhat)
 listCmd' str = list2 (words str)
 
@@ -3536,7 +3620,7 @@ list2 [arg] = do
                   noCanDo name $ text "can't find its location: " <>
                                  ppr loc
     where
-        noCanDo n why = printForUser $
+        noCanDo n why = printForUser stdout $
             text "cannot list source code for " <> ppr n <> text ": " <> why
 list2  _other =
         liftIO $ putStrLn "syntax:  :list [<line> | <module> <line> | <identifier>]"
@@ -3673,8 +3757,8 @@ deleteBreak identity = do
    let oldLocations    = breaks st
        (this,rest)     = partition (\loc -> fst loc == identity) oldLocations
    if null this
-      then printForUser (text "Breakpoint" <+> ppr identity <+>
-                         text "does not exist")
+      then printForUser stdout (text "Breakpoint" <+> ppr identity <+>
+                                text "does not exist")
       else do
            mapM_ (turnOffBreak.snd) this
            setGHCiState $ st { breaks = rest }


### PR DESCRIPTION
### This PR adds

* To the Intero executable: 
   1. The ability for read-only commands (`:type-at`, `:loc-at`, `:complete-at`, `:uses-at`) to be **called in a separate thread** to the main thread, which may be compiling a module. List [here](https://github.com/commercialhaskell/intero/blob/76ba40109ada211d76bf435ea6cb8c16227d68d5/src/InteractiveUI.hs#L301..L308). 
   2. A simple TCP service that listens on a _random available port_ on loopback (127.0.0.1-only), which is reported when it starts up as `Intero-Service-Port`.
* For the Emacs mode, 
    1. We pick up the `Intero-Service-Port`  when starting the Intero process. 
    2. We add two new functions `intero-async-network-call` and `intero-blocking-network-call` which both connect to the service. _One new connection per command request_, and after the response is sent the connection is closed. If the connection cannot be established, we fall back to talking to the intero pipe as usual.

### Why?

Because when flycheck is running which calls `:load` on the current module, if your module is big, you'll have to wait until the check is done before any other commands (listed above) can run. The intero process often already has this information, but the command queue can only run one at a time.

This makes the user experience much faster. You can edit code and get goto-definition, type info, completions, much faster than before.

### Demonstration

**Before**, notice how you have to wait for the type-check to complete (see the `FlyC*` at the bottom right) before the completion is able to trigger (we could change the hook order, but that actually doesn't improve anything):

![screenflow](https://user-images.githubusercontent.com/11019/36035441-d41cbb44-0dae-11e8-818f-f20030e86133.gif)

**After**, notice that the reply is immediate even though we're currently compiling the module. See the `FlyC` at the bottom right change.

![screenflow-fast](https://user-images.githubusercontent.com/11019/36035585-3b388de4-0daf-11e8-8779-52d8d68e17ad.gif)

## Testing

I'm going to work for the rest of the day with this branch and generally be aware of any misbehavior.
Meanwhile the CI will check that the changes to the intero executable build properly.