### PR TITLE
Check if UseLoopBack socket option is supported

### DIFF
--- a/src/InteractiveUI.hs
+++ b/src/InteractiveUI.hs
@@ -678,7 +678,10 @@ listenOnLoopback = do
     close
     (\sock -> do
        setSocketOption sock ReuseAddr 1
-       setSocketOption sock UseLoopBack 1
+       if isSupportedSocketOption UseLoopBack then
+         setSocketOption sock UseLoopBack 1
+       else
+         return ()
        address <- getHostByName "127.0.0.1"
        bind sock (SockAddrInet aNY_PORT (hostAddress address))
        listen sock maxListenQueue


### PR DESCRIPTION
Not all systems support the UseLoopBack socket option.
Network.Socket.setSocketOption throws an exception when a system doesn't
support the socket option. This commit checks if the system supports
`UseLoopBack` before attempting to set it.

Fixes https://github.com/commercialhaskell/intero/issues/518