### PR TITLE
Revert "Delete network buffers after use"

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -2065,39 +2065,33 @@ as (CALLBACK STATE REPLY)."
       (error "Intero process is not running: run M-x intero-restart to start it"))))
 
 (defun intero-network-call-sentinel (process event)
-  (let ((buf (process-buffer process)))
-    (cl-flet ((cleanup ()
-                 (delete-process process)
-                 (kill-buffer buf)))
-      (if (string= "open\n" event)
-          (let ((cmd
-                 (with-current-buffer buf
-                   (when intero-debug (message "Connected to service, sending %S" intero-async-network-cmd))
-                   (setq intero-async-network-connected t)
-                   (and intero-async-network-cmd
-                        (concat intero-async-network-cmd "\n")))))
-            (if cmd
-                (process-send-string process cmd)
-              (cleanup)))
-        (with-current-buffer buf
-          (if intero-async-network-connected
-              (when intero-async-network-callback
-                (when intero-debug (message "Calling callback with %S" (buffer-string)))
-                (funcall intero-async-network-callback
-                         intero-async-network-state
-                         (buffer-string)))
-            ;; We didn't successfully connect, so let's fallback to the
-            ;; process pipe.
+  (with-current-buffer (process-buffer process)
+    (if (string= "open\n" event)
+        (progn
+          (when intero-debug (message "Connected to service, sending %S" intero-async-network-cmd))
+          (setq intero-async-network-connected t)
+          (if intero-async-network-cmd
+              (process-send-string process (concat intero-async-network-cmd "\n"))
+            (delete-process process)))
+      (progn
+        (if intero-async-network-connected
             (when intero-async-network-callback
-              (when intero-debug (message "Failed to connect, falling back ... "))
-              (setq intero-async-network-callback nil)
-              (intero-async-call
-               intero-async-network-worker
-               intero-async-network-cmd
-               intero-async-network-state
-               intero-async-network-callback))))
+              (when intero-debug (message "Calling callback with %S" (buffer-string)))
+              (funcall intero-async-network-callback
+                       intero-async-network-state
+                       (buffer-string)))
+          ;; We didn't successfully connect, so let's fallback to the
+          ;; process pipe.
+          (when intero-async-network-callback
+            (when intero-debug (message "Failed to connect, falling back ... "))
+            (setq intero-async-network-callback nil)
+            (intero-async-call
+             intero-async-network-worker
+             intero-async-network-cmd
+             intero-async-network-state
+             intero-async-network-callback)))
         ;; In any case we clean up the connection.
-        (cleanup)))))
+        (delete-process process)))))
 
 (defun intero-async-call (worker cmd &optional state callback)
   "Send WORKER the command string CMD.


### PR DESCRIPTION
Reverts commercialhaskell/intero#523

With the above change, I see a lot of:

```
Debugger entered--Lisp error: (error "Selecting deleted buffer")
  intero-network-call-sentinel(#<process backend> "deleted\n")
```

so it seems like this fix isn't the correct one.

/cc @sergv 