### PR TITLE
Properly and consistently quote file paths for GHCi :commands

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -330,10 +330,6 @@ This is slower, but will build required dependencies.")
 (defvar-local intero-ghc-version nil
   "GHC version used by the project.")
 
-(defvar-local intero-repl-last-loaded
-  nil
-  "The last loaded thing with `intero-repl-load`.")
-
 (defvar-local intero-buffer-host nil
   "The hostname of the box hosting the intero process for the current buffer.")
 
@@ -1258,8 +1254,7 @@ If PROMPT-OPTIONS is non-nil, prompt with an options list."
     (intero-with-repl-buffer prompt-options
       (comint-simple-send
        (get-buffer-process (current-buffer))
-       (concat ":load " file))
-      (setq intero-repl-last-loaded file))))
+       (concat ":load " file)))))
 
 (defun intero-repl-eval-region (begin end &optional prompt-options)
   "Evaluate the code in region from BEGIN to END in the REPL.
@@ -1360,7 +1355,6 @@ load.  If PROMPT-OPTIONS is non-nil, prompt with an options list.
 STACK-YAML is the stack yaml config to use.  When nil, tries to
 use project-wide intero-stack-yaml when nil, otherwise uses
 stack's default)."
-  (setq intero-repl-last-loaded nil)
   (setq intero-targets targets)
   (when stack-yaml
     (setq intero-stack-yaml stack-yaml))


### PR DESCRIPTION
- Quote all paths with ""
- Escape only \ and "
- Don't rely on %S elisp string escaping
- Remove special-case handling for :move

This allows all commands to safely handle Windows paths and both directory paths and filenames which contain spaces on any platform.

This should replace #541 if it is found to work for all concerned - I've tested this on a UNIX machine to my satisfaction.
