### PR TITLE
Remove -odir/-hidir, trust stack ghci to set them

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -2400,11 +2400,6 @@ default when nil)."
           (when ignore-dot-ghci
             (list "--ghci-options" "-ignore-dot-ghci"))
           (cl-mapcan (lambda (x) (list "--ghci-options" x)) intero-extra-ghc-options)
-          (let ((dir (intero-localize-path (intero-make-temp-file "intero" t))))
-            (list "--ghci-options"
-                  (concat "-odir=" dir)
-                  "--ghci-options"
-                  (concat "-hidir=" dir)))
           targets))
 
 (defun intero-sentinel (process change)


### PR DESCRIPTION
stack already sets the `-odir` and `-hidir` to a place in `.stack-work` which is stable and cacheable.

Removing this makes intero much faster at restarting on large projects, because all the object files are cached.

Here is a sample intero debug log, two intero-restart invocations: https://gist.github.com/chrisdone/35d870f02180793b132646f637373fe0

That is, once PR #4038 lands:

https://github.com/commercialhaskell/stack/pull/4038

Until that lands the user won't notice a difference.