### PR TITLE
Add option to show warnings even when errors exist

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -157,6 +157,11 @@ by default."
   :group 'intero
   :type '(repeat string))
 
+(defcustom intero-show-warnings-when-errors-exist nil
+  "Show GHC warnings even when the file has errors"
+  :group 'intero
+  :type 'boolean)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Modes
 
@@ -816,7 +821,7 @@ CHECKER and BUFFER are added to each item parsed from STRING."
                       messages)))
         (forward-line -1))
       (delete-dups
-       (if found-error-as-warning
+       (if (and intero-show-warnings-when-errors-exist found-error-as-warning)
            (cl-remove-if (lambda (msg) (eq 'warning (flycheck-error-level msg))) messages)
          messages)))))
 


### PR DESCRIPTION
One important use case is to be able to put a typed hole somewhere and still get warnings for the rest of the code.