### PR TITLE
Restart GHC in intero-repl-buffer if repl buffer already exists

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -1341,7 +1341,9 @@ STORE-PREVIOUS is non-nil, note the caller's buffer in
          (initial-buffer (current-buffer))
          (backend-buffer (intero-buffer 'backend)))
     (with-current-buffer
-        (or (get-buffer name)
+        (or (let ((buf (get-buffer name)))
+              (and buf
+                   (get-buffer-process buf)))
             (with-current-buffer
                 (get-buffer-create name)
               ;; The new buffer doesn't know if the initial buffer was hosted


### PR DESCRIPTION
This can occur if GHC died with a segfault, for example.