### PR TITLE
Return the buffer instead of the process when creating the repl buffer

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -1342,8 +1342,8 @@ STORE-PREVIOUS is non-nil, note the caller's buffer in
          (backend-buffer (intero-buffer 'backend)))
     (with-current-buffer
         (or (let ((buf (get-buffer name)))
-              (and buf
-                   (get-buffer-process buf)))
+              (and (get-buffer-process buf)
+                   buf))
             (with-current-buffer
                 (get-buffer-create name)
               ;; The new buffer doesn't know if the initial buffer was hosted


### PR DESCRIPTION
This fixes #570 . `and` blocks in elisp return the last "truthy" value, otherwise nil. #570 as a result returned the process and not the buffer when the `and` expression was true, resulting to an error described in #572 .