### PR TITLE
Networked intero

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -2098,7 +2098,7 @@ as (CALLBACK STATE REPLY)."
       (let ((buffer (intero-buffer worker)))
         (if (and buffer (process-live-p (get-buffer-process buffer)))
             (with-current-buffer buffer
-              (let ((port (intero-read-port default-directory)))
+              (let ((port (intero-read-port)))
                 (if port
                     (let* ((buffer (generate-new-buffer (format " intero-network:%S" worker)))
                            (process
@@ -2183,9 +2183,7 @@ If provided, use the specified TARGETS, SOURCE-BUFFER and STACK-YAML."
   (let* ((buffer (intero-get-buffer-create worker)))
     (if (get-buffer-process buffer)
         buffer
-      (let ((port (intero-read-port
-                   (or (and stack-yaml (file-name-directory stack-yaml))
-                       (intero-project-root)))))
+      (let ((port (intero-read-port)))
         (if port
             (intero-start-process-in-buffer buffer targets source-buffer stack-yaml port)
           (let ((install-status (intero-installed-p)))
@@ -2193,9 +2191,9 @@ If provided, use the specified TARGETS, SOURCE-BUFFER and STACK-YAML."
                 (intero-start-process-in-buffer buffer targets source-buffer stack-yaml)
               (intero-auto-install buffer install-status targets source-buffer stack-yaml))))))))
 
-(defun intero-read-port (stack-dir)
+(defun intero-read-port ()
   "Read a port number from the file at `intero-port-file'."
-  (let ((fp (concat stack-dir "/" intero-port-file)))
+  (let ((fp (concat (intero-project-root) "/" intero-port-file)))
     (when (file-exists-p fp)
       (with-temp-buffer
         (insert-file-contents fp)

--- a/src/GhciMonad.hs
+++ b/src/GhciMonad.hs
@@ -359,9 +359,9 @@ resume canLogSpan step = do
 -- --------------------------------------------------------------------------
 -- timing & statistics
 
-timeIt :: InputT GHCi a -> InputT GHCi a
+timeIt :: GHCi a -> GHCi a
 timeIt action
-  = do b <- lift $ isOptionSet ShowTiming
+  = do b <- isOptionSet ShowTiming
        if not b
           then action
           else do allocs1 <- liftIO $ getAllocations

--- a/src/InteractiveUI.hs
+++ b/src/InteractiveUI.hs
@@ -815,6 +815,7 @@ runServer state mutex =
   withSocketsDo
     (do sock <- listenOnLoopback
         port <- fmap fromIntegral (socketPort sock) :: IO Int
+        createDirectoryIfMissing ".intero" True
         writeFile ".intero/port" (show port)
         let loop = do
               (h, _, _) <- Network.accept sock

--- a/src/InteractiveUI.hs
+++ b/src/InteractiveUI.hs
@@ -895,11 +895,8 @@ defaultLogActionH h dflags reason severity srcSpan style msg
       printWarns = do
         hPutChar h '\n'
         caretDiagnostic <-
-            if gopt Opt_DiagnosticsShowCaret dflags
-            then getCaretDiagnostic severity srcSpan
-            else pure empty
-        printErrs (message $+$ caretDiagnostic)
-            (setStyleColoured True style)
+            pure empty
+        printErrs (message $+$ caretDiagnostic)style
         -- careful (#2302): printErrs prints in UTF-8,
         -- whereas converting to string first and using
         -- hPutStr would just emit the low 8 bits of
@@ -920,21 +917,21 @@ defaultLogActionH h dflags reason severity srcSpan style msg
           --     ", -Werror=" ++ flagSpecName spec
 
       warnFlagGrp flag
-          | gopt Opt_ShowWarnGroups dflags =
-                case smallestGroups flag of
-                    [] -> ""
-                    groups -> " (in " ++ intercalate ", " (map ("-W"++) groups) ++ ")"
+          -- | gopt Opt_ShowWarnGroups dflags =
+          --       case smallestGroups flag of
+          --           [] -> ""
+          --           groups -> " (in " ++ intercalate ", " (map ("-W"++) groups) ++ ")"
           | otherwise = ""
-        where smallestGroups :: WarningFlag -> [String]
-              smallestGroups fl = mapMaybe go warningHierarchies where
-                  -- Because each hierarchy is arranged from smallest to largest,
-                  -- the first group we find in a hierarchy which contains the flag
-                  -- is the smallest.
-                  go (gr:rest) = fromMaybe (go rest) $ do
-                      flags <- lookup gr warningGroups
-                      guard (fl `elem` flags)
-                      pure (Just gr)
-                  go [] = Nothing
+        -- where smallestGroups :: WarningFlag -> [String]
+        --       smallestGroups fl = mapMaybe go warningHierarchies where
+        --           -- Because each hierarchy is arranged from smallest to largest,
+        --           -- the first group we find in a hierarchy which contains the flag
+        --           -- is the smallest.
+        --           go (gr:rest) = fromMaybe (go rest) $ do
+        --               flags <- lookup gr warningGroups
+        --               guard (fl `elem` flags)
+        --               pure (Just gr)
+        --           go [] = Nothing
 
 -- | Find the 'FlagSpec' for a 'WarningFlag'.
 flagSpecOf :: WarningFlag -> Maybe (FlagSpec WarningFlag)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-11.13
+resolver: lts-8.23
 
 nix:
   packages: [ ncurses clang ]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-10.0
+resolver: lts-11.13
 
 nix:
   packages: [ ncurses clang ]


### PR DESCRIPTION
Pinging @purcell.

This is a rather substantial change to intero. I've yet to run the GHC test suites, this serves as a preview PR that I'm testing on work projects. It's not a big change to the elisp, but the executable has changed a fair bit.

# The problem

Currently, Emacs launches intero the binary as a piped process and controls it end to end, with `stack` wrapping it up with all the right packages and target choices. This provides a great user experience, but sometimes you need to launch intero outside of your regular environment. Think:

* Working on a client nix project
* Working on something inside a docker container
* Working on something inside a VM (e.g. VirtualBox)

In each of these cases, the way to invoke intero can be complicated.

# The solution

Change the way Emacs talks to intero. Make it talk over a network for everything.

* Emacs already abstracts over whether you're talking to a piped process or a network socket with the same API. This code basically didn't have to change. I simply changed the launcher to either:
  1. If Intero is already running on a port, just connect to that instead with `make-network-process`.
  2. If intero isn't running, then start it ourselves with the existing `start-file-process` call.

I've tested this with an intero invocation inside a docker-compose project, with port 1234 exposed. I specify `INTERO_SERVICE_PORT=1234` and intero starts, listens on that port, and writes `1234` to `.intero/port`. Emacs automatically checks for this file and auto-connects to that process. 

You have to make sure that Emacs and the docker/vm container share the same directory roots with e.g. `docker run -v$(pwd):$(pwd)`.

As for the intero binary, the main change is that all commands will either write to stdout or a handle to a socket. Additionally, compiler messages are captured and written to the socket instead of directly to stdout/stderr.

This also represents a step forward to moving away from pretending to be a commandline app and closer to being a networked service. It also represents a step toward something like Microsoft's standard IDE protocol. But I'd hope by that point we can all switch to HIE.

# Remaining work

 Some stand-out issues:

* The Emacs lisp code could use the concept of "workers" already built into intero's internal API, and do away with the "network call" that I implemented earlier this year (or last?). Instead, we'd have the regular `'backend` worker and then a `'readonly` worker which does readonly commands (querying).
* We may have to update tramp support, or consider removing it and recommending rsync/sshfs.
* Testing on windows?
* Test on various GHCs.
* If we go forward with this approach, we ought to make it continue to work in the usual piped fashion, so that upstream users (vim, VS Code, etc.) don't have to make any changes.