### PR TITLE
GHC 8.6.3

### DIFF
--- a/intero.cabal
+++ b/intero.cabal
@@ -73,7 +73,7 @@ executable intero
     bytestring,
     directory,
     filepath,
-    ghc >= 7.8 && <= 8.6.1,
+    ghc >= 7.8 && <= 8.6.3,
     ghc-paths,
     haskeline,
     process,

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -59,6 +59,13 @@ argsparser =
              ":type-at"
              "<no location info>: Expected a span: \"<module-name/filepath>\" <start line> <start column> <end line> <end column> \"<sample string>\"\n"))
 
+maybeModuleStr :: String
+#if __GLASGOW_HASKELL__ >= 806
+maybeModuleStr = "GHC.Maybe"
+#else
+maybeModuleStr = "GHC.Base"
+#endif
+
 -- | Basic commands that should work out of the box.
 basics :: Spec
 basics =
@@ -70,7 +77,7 @@ basics =
           (do reply <- withIntero [] (\_ repl -> repl ":i Nothing")
               shouldBe
                 (subRegex (mkRegex "Data.Maybe") reply "GHC.Base")
-                ("data Maybe a = Nothing | ... \t-- Defined in " ++ (quote "GHC.Base") ++ "\n"))
+                ("data Maybe a = Nothing | ... \t-- Defined in " ++ (quote maybeModuleStr) ++ "\n"))
         it ":k Just" (eval ":k Maybe" "Maybe :: * -> *\n"))
   where
     quote s = opQuote : s ++ [clQuote]


### PR DESCRIPTION
I do not claim to understand exactly what's going on here, but I do claim that this version of the test suite passes with all of the following builds:

```
$ stack test
$ stack --resolver lts-12.25 test
$ stack --resolver lts-13.0 test
```

I also did some very rudimentary manual testing via

```
$ stack --resolver lts-13.0 build --copy-compiler-tool
```

and it seems to be working as intended.