### PR TITLE
replace append by concat for flag generation

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -1886,7 +1886,7 @@ type as arguments."
                  (lambda (flag)
                    (intero-async-call
                     'backend
-                    (append ":set " flag)))
+                    (concat ":set " flag)))
                  (intero-ghci-output-flags))
                (replace-regexp-in-string
                 "\n$" ""
@@ -2332,7 +2332,7 @@ Uses the default stack config file, or STACK-YAML file if given."
       (set-process-query-on-exit-flag process nil)
       (mapc
        (lambda (flag)
-         (process-send-string process (append ":set " flag "\n")))
+         (process-send-string process (concat ":set " flag "\n")))
        (intero-ghci-output-flags))
       (process-send-string process ":set -fdefer-type-errors\n")
       (process-send-string process ":set -fdiagnostics-color=never\n")

--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -2668,7 +2668,7 @@ For debugging purposes, try running the following in your terminal:
 (defun intero-ghci-output-flags ()
   "Get the appropriate ghci output flags for the current GHC version"
   (with-current-buffer (intero-buffer 'backend)
-    (let ((current-version (mapcar #'string-to-number (split-string intero-ghc-version "\\."))))
+    (let ((current-version (mapcar #'string-to-number (split-string (intero-ghc-version) "\\."))))
     (if (intero-version>= '(8 4 1) current-version)
         '("-fno-code" "-fwrite-interface")
         '("-fobject-code")))))


### PR DESCRIPTION
Hello,
This is my first participation in an open source project, so please tell me if I'm doing anything wrong :)

I tracked this bug from this (see my answer):
https://stackoverflow.com/questions/59058854/intero-error-wrong-type-argument-stringp-nil

NB I didn't quite solve the original problem (intero-ghc-version not being set immediately), but this one was easier to pinpoint.

The bug was introduced by 0a87ecaf98950eae7516613ffc84f901bbf48f54 

I hope this helps!

Best,
Mikael